### PR TITLE
doesnt work correctly if length is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (stream, options, done) {
 
   // convert the expected length to an integer
   var length = null
-  if (!isNaN(options.length))
+  if (options.length && !isNaN(options.length))
     length = parseInt(options.length, 10)
 
   // check the length and limit options.

--- a/test/index.js
+++ b/test/index.js
@@ -168,6 +168,17 @@ describe('Raw Body', function () {
     })
   })
 
+  it('should work with if length is null', function (done) {
+    getRawBody(createStream(), {
+      length: null,
+      limit: length + 1
+    }, function (err, buf) {
+      assert.ifError(err)
+      checkBuffer(buf)
+      done()
+    })
+  })
+
   it('should work with {"test":"å"}', function (done) {
     // https://github.com/visionmedia/express/issues/1816
 


### PR DESCRIPTION
currently if length is null or blank,
!isNan(options.length) return true, 
and length = parseInt(options.length, 10); makes length NaN, which doesnt matches with subsequent length != null check in various places

Coz of this we are facing following issue
https://github.com/visionmedia/express/issues/1816#issuecomment-35760090
