### PR TITLE
Attach 'data' event listener last, as it fails in nodejs v0.10.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,10 +221,10 @@ function readStream(stream, encoding, length, limit, callback) {
     : []
 
   stream.on('aborted', onAborted)
-  stream.on('data', onData)
   stream.once('end', onEnd)
   stream.once('error', onEnd)
   stream.once('close', cleanup)
+  stream.on('data', onData)
 
   function done(err) {
     cleanup()


### PR DESCRIPTION
In nodejs v0.10.x, when attaching a data event listener, it will start in the same tick, and thus before the 'end', 'error' and 'close' listeners in raw-body are attached. 
When there then occurs an error due to exceeding ```opts.limit```, the 'done' handler in raw-body runs some cleanup code, among others it detaches the event handlers - however this happens before those listeners got attached, as it's called in the same tick.

This pull request switches the order of attaching the event listeners which works around the problem. I have been trying to write a failing test for it, but didn't manage.

From https://github.com/nodejs/node/commit/0f8de5e1f96a07fa6de837378d29ac5f2719ec60 onward (v0.11.5+) nodejs doesn't have this issue anymore, as it uses 'resume' which does do its work in the next tick.