### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var getRawBody = require('raw-body')
 
 Options:
 
-- `length` - The length length of the stream.
+- `length` - The length of the stream.
   If the contents of the stream do not add up to this length,
   an `400` error code is returned.
 - `limit` - The byte limit of the body.


### PR DESCRIPTION
Noticed "length" twice in a row in the README.  Tiny fix!

Thanks,

K