### PR TITLE
Avoid cleaning up listeners and buffers twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,7 +309,10 @@ function readStream (stream, encoding, length, limit, callback) {
     }
   }
 
+  var cleanedUp = false
+
   function cleanup () {
+    if (cleanedUp) return
     buffer = null
 
     stream.removeListener('aborted', onAborted)
@@ -317,5 +320,7 @@ function readStream (stream, encoding, length, limit, callback) {
     stream.removeListener('end', onEnd)
     stream.removeListener('error', onEnd)
     stream.removeListener('close', cleanup)
+
+    cleanedUp = true
   }
 }


### PR DESCRIPTION
This small pull request patches `readStream` to avoid running its `cleanup` routine twice.  It's an optimization.  I don't believe it affects input, output, or state.

It makes sense to register `cleanup` as a listener to the `close` event, since, IIRC, `close` might emit without `end` in some situations.  However, since other listeners, like `onEnd`, already invoke `cleanup`, especially via `invokeCallback`, `cleanup` is getting called twice.

I was able to confirm this by inserting `console.log` statements to trace execution.  Forgive me for not including a test for the new change; I think this is pure optimization.