### PR TITLE
Fixed Spelling Error in Typescript Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install raw-body
 ### TypeScript
 
 This module includes a [TypeScript](https://www.typescriptlang.org/)
-declarition file to enable auto complete in compatible editors and type
+declaration file to enable auto complete in compatible editors and type
 information for TypeScript projects. This module depends on the Node.js
 types, so install `@types/node`:
 


### PR DESCRIPTION
decliration spells correctly as "declaration"