### PR TITLE
check stream readable

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,10 @@ function readStream (stream, encoding, length, limit, callback) {
     }))
   }
 
+  if (stream.hasOwnProperty('readable') && !stream.readable) {
+    return done(createError(500, 'stream should be readable'))
+  }
+
   var received = 0
   var decoder
 

--- a/test/index.js
+++ b/test/index.js
@@ -112,6 +112,17 @@ describe('Raw Body', function () {
     })
   })
 
+  it('should throw if stream is not readable', function (done) {
+    var stream = new Readable();
+    stream.readable = false;
+
+    getRawBody(stream, function(err, buf) {
+      assert.equal(err.status, 500);
+      assert.equal(err.message, 'stream should be readable');
+      done();
+    });
+  });
+
   it('should work with an empty stream', function (done) {
     var stream = new Readable()
     stream.push(null)


### PR DESCRIPTION
Add check for stream in situation #57 ,if the `stream.readable` is `false`, there will be an error instead of endless waiting. 