### PR TITLE
Bump iconv-lite version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "bytes": "3.1.0",
     "http-errors": "1.7.3",
-    "iconv-lite": "0.4.24",
+    "iconv-lite": "0.5.0",
     "unpipe": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR bump `iconv-lite` to `0.5.0`.

It will be remove 
```
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
deprecation message.