### PR TITLE
[http2] Force complete if all data received

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,6 +253,14 @@ function readStream (stream, encoding, length, limit, callback) {
     } else {
       buffer.push(chunk)
     }
+
+    if (received === length) {
+      // force completion if we've already received the desired length.
+      // this resolves a problem with some http2 connections where the
+      // request stream does not fire `end` event until after the request
+      // times out.
+      onEnd();
+    }
   }
 
   function onEnd (err) {


### PR DESCRIPTION
This was a significant bug for us resulting in requests failing intermittently. Very difficult to reproduce, which is why I didn't create a special test -- perhaps someone more familiar could. Looking through node's http2 issues, not clear if this is something that will ever be resolved in their stack. This workaround should be reliable and safe to do in any scenario.