### PR TITLE
Update types stream.Readable with NodeJS.ReadableStream

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 3.x
 ===
 
+  * Change TypeScript argument to `NodeJS.ReadableStream` interface
   * Drop support for Node.js 0.8
   * deps: iconv-lite@0.5.2
     - Add encoding cp720

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import { Readable } from 'stream';
-
 declare namespace getRawBody {
   export type Encoding = string | true;
 
@@ -58,29 +56,29 @@ declare namespace getRawBody {
  * limit. Ideal for parsing request bodies.
  */
 declare function getRawBody(
-  stream: Readable,
+  stream: NodeJS.ReadableStream,
   callback: (err: getRawBody.RawBodyError, body: Buffer) => void
 ): void;
 
 declare function getRawBody(
-  stream: Readable,
+  stream: NodeJS.ReadableStream,
   options: (getRawBody.Options & { encoding: getRawBody.Encoding }) | getRawBody.Encoding,
   callback: (err: getRawBody.RawBodyError, body: string) => void
 ): void;
 
 declare function getRawBody(
-  stream: Readable,
+  stream: NodeJS.ReadableStream,
   options: getRawBody.Options,
   callback: (err: getRawBody.RawBodyError, body: Buffer) => void
 ): void;
 
 declare function getRawBody(
-  stream: Readable,
+  stream: NodeJS.ReadableStream,
   options: (getRawBody.Options & { encoding: getRawBody.Encoding }) | getRawBody.Encoding
 ): Promise<string>;
 
 declare function getRawBody(
-  stream: Readable,
+  stream: NodeJS.ReadableStream,
   options?: getRawBody.Options
 ): Promise<Buffer>;
 


### PR DESCRIPTION
In TypeScript, NodeJS.ReadableStream is the interface, whereas stream.Readable is a specific implementation of NodeJS.ReadableStream. I believe this library should work with all readable streams, and so should accept the more general interface rather than just stream.Readable 