### PR TITLE
Include limit + length in "request entity too large" messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,8 @@ function readStream (stream, encoding, length, limit, callback) {
   // note: we intentionally leave the stream paused,
   // so users should handle the stream themselves.
   if (limit !== null && length !== null && length > limit) {
-    return done(createError(413, 'request entity too large', {
+    var message = 'request entity too large (limit is ' + limit + ' bytes; expecting ' + length + ')'
+    return done(createError(413, message, {
       expected: length,
       length: length,
       limit: limit,
@@ -243,7 +244,8 @@ function readStream (stream, encoding, length, limit, callback) {
     received += chunk.length
 
     if (limit !== null && received > limit) {
-      done(createError(413, 'request entity too large', {
+      var message = 'request entity too large (limit is ' + limit + ' bytes; received ' + received + ')'
+      done(createError(413, message, {
         limit: limit,
         received: received,
         type: 'entity.too.large'

--- a/test/flowing.js
+++ b/test/flowing.js
@@ -21,7 +21,7 @@ describe('stream flowing', function () {
       }, function (err, body) {
         assert.ok(err)
         assert.strictEqual(err.type, 'entity.too.large')
-        assert.strictEqual(err.message, 'request entity too large')
+        assert.match(err.message, /request entity too large/)
         assert.strictEqual(err.statusCode, 413)
         assert.strictEqual(err.length, defaultLimit * 2)
         assert.strictEqual(err.limit, defaultLimit)
@@ -45,10 +45,27 @@ describe('stream flowing', function () {
       }, function (err, body) {
         assert.ok(err)
         assert.strictEqual(err.type, 'entity.too.large')
-        assert.strictEqual(err.message, 'request entity too large')
+        assert.match(err.message, /request entity too large/)
         assert.strictEqual(err.statusCode, 413)
         assert.strictEqual(body, undefined)
         assert.ok(stream.isPaused)
+        done()
+      })
+    })
+
+    it('should indicate to receivers what the limit is', function (done) {
+      var stream = createInfiniteStream(true)
+      var dest = createBlackholeStream()
+
+      // pipe the stream
+      stream.pipe(dest)
+
+      getRawBody(stream, {
+        limit: defaultLimit * 2,
+        length: defaultLimit
+      }, function (err, body) {
+        assert.strictEqual(err.type, 'entity.too.large')
+        assert.match(err.message, new RegExp('request entity too large \\(limit is ' + (defaultLimit * 2) + ' bytes; received \\d+\\)'))
         done()
       })
     })

--- a/test/index.js
+++ b/test/index.js
@@ -108,7 +108,7 @@ describe('Raw Body', function () {
       assert.strictEqual(err.length, length)
       assert.strictEqual(err.limit, length - 1)
       assert.strictEqual(err.type, 'entity.too.large')
-      assert.strictEqual(err.message, 'request entity too large')
+      assert.strictEqual(err.message, 'request entity too large (limit is ' + (length - 1) + ' bytes; expecting ' + length + ')')
       done()
     })
   })


### PR DESCRIPTION
So that requesters (e.g. HTTP* callers) can have a better understanding of what they did wrong, include the byte limit in the error message so that it flows all the way across the wire.