### PR TITLE
fix: Add `types` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "engines": {
     "node": ">= 0.8"
   },
+  "types": "index.d.ts",
   "files": [
     "HISTORY.md",
     "LICENSE",


### PR DESCRIPTION
The upcoming TypeScript 4.5.0 version has a new stricter module resolution algorithm that more closely follows Node's resolution: `node12`. It requires packages to explicitly define their exported types, either with a `types` or `export.types` field in `package.json`.

This commit fixes the `package.json` so it can be consumed by projects using TypeScript 4.5.0 and the `node12` resolution algorithm.