### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           node-version: "17.6"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
@@ -186,7 +186,7 @@ jobs:
         fi
 
     - name: Upload code coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: steps.list_env.outputs.nyc != ''
       with:
         name: coverage
@@ -197,14 +197,14 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install lcov
       shell: bash
       run: sudo apt-get -y install lcov
 
     - name: Collect coverage reports
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: coverage
         path: ./coverage


### PR DESCRIPTION
Bumps GitHub Actions to their latest major versions. Main change is they're now using Node 16 instead of 12, which was EOL at the end of April.

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)
- Releases for `actions/upload-artifact` can be [found here](https://github.com/actions/upload-artifact/releases)
- Releases for `actions/download-artifact` can be [found here](https://github.com/actions/download-artifact)