### PR TITLE
deps: remove `unpipe` and use native `stream.unpipe()`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+  * deps: remove `unpipe` and use native `stream.unpipe()`
+
 3.0.0 / 2024-07-25
 ==================
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ var asyncHooks = tryRequireAsyncHooks()
 var bytes = require('bytes')
 var createError = require('http-errors')
 var iconv = require('iconv-lite')
-var unpipe = require('unpipe')
 
 /**
  * Module exports.
@@ -133,7 +132,7 @@ function getRawBody (stream, options, callback) {
 
 function halt (stream) {
   // unpipe everything from the stream
-  unpipe(stream)
+  stream.unpipe()
 
   // pause stream
   if (typeof stream.pause === 'function') {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "bytes": "3.1.2",
     "http-errors": "2.0.0",
-    "iconv-lite": "0.6.3",
-    "unpipe": "1.0.0"
+    "iconv-lite": "0.6.3"
   },
   "devDependencies": {
     "bluebird": "3.7.2",


### PR DESCRIPTION
The [`unpipe`](https://www.npmjs.com/package/unpipe) package was used to unpipes all destinations from a given stream.

Taken from the unpipe readme:

> With stream 2+, this is equivalent to stream.unpipe(). When used with streams 1 style streams (typically Node.js 0.8 and below), this module attempts to undo the actions done in stream.pipe(dest).