### PR TITLE
Loosen dependency requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "license": "MIT",
   "repository": "stream-utils/raw-body",
   "dependencies": {
-    "bytes": "3.1.2",
-    "http-errors": "2.0.0",
-    "iconv-lite": "0.6.3",
-    "unpipe": "1.0.0"
+    "bytes": "^3.1.2",
+    "http-errors": "^2.0.0",
+    "iconv-lite": "^0.6.3",
+    "unpipe": "^1.0.0"
   },
   "devDependencies": {
     "bluebird": "3.7.2",


### PR DESCRIPTION
Using exact dependency versions can be harmful, as it blocks downstream bug fixes, security patches, and new features. It can also increase the risk of duplicate packages in node_modules, leading to subtle, hard-to-debug issues.

This PR changes all user-facing dependencies from x.y.z to ^x.y.z, allowing end users to automatically benefit from compatible updates as they are released.