### PR TITLE
deps: use tilde notation for dependencies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==================
 
+  * deps: http-errors@2.0.1
   * deps: use tilde notation for dependencies
 
 3.0.1 / 2025-09-03

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "repository": "stream-utils/raw-body",
   "dependencies": {
     "bytes": "~3.1.2",
-    "http-errors": "~2.0.0",
+    "http-errors": "~2.0.1",
     "iconv-lite": "~0.7.0",
     "unpipe": "~1.0.0"
   },


### PR DESCRIPTION
This PR has 2 commits: 
  * deps: http-errors@2.0.1
  * deps: use tilde notation for dependencies
  
 This would allow deduplicating the `http-errors` package in the `express` v5 dependency tree: https://npmgraph.js.org/?q=express
 
 Ideally we can release this as `v3.0.2` as fast as possible.
 
 cc @UlisesGascon @bjohansebas 