### PR TITLE
chore: remove history.md and security.md from being packaged on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,8 @@
     "node": ">= 0.10"
   },
   "files": [
-    "HISTORY.md",
     "LICENSE",
     "README.md",
-    "SECURITY.md",
     "index.d.ts",
     "index.js"
   ],


### PR DESCRIPTION
We don’t need to upload these two files to npm; it reduces the package size, especially for servers that have limited disk space
old:
package size: 9.5 kB
unpacked size: 28.0 kB

new:
package size: 6.3 kB
unpacked size: 18.5 kB