### PR TITLE
fix: handle invalid length values (Infinity, negative, NaN)

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,9 +107,14 @@ function getRawBody (stream, options, callback) {
   var limit = bytes.parse(opts.limit)
 
   // convert the expected length to an integer
-  var length = opts.length != null && !isNaN(opts.length)
-    ? parseInt(opts.length, 10)
-    : null
+  var length = null
+  if (opts.length != null && !isNaN(opts.length)) {
+    var parsedLength = parseInt(opts.length, 10)
+
+    if (!isNaN(parsedLength) && isFinite(parsedLength) && parsedLength >= 0) {
+      length = parsedLength
+    }
+  }
 
   if (done) {
     // classic callback style

--- a/test/index.js
+++ b/test/index.js
@@ -186,6 +186,36 @@ describe('Raw Body', function () {
     })
   })
 
+  it('should handle invalid length values (Infinity, negative, NaN)', function (done) {
+    var testData = 'test data'
+    var expectedLength = testData.length
+
+    var stream = new Readable()
+    stream.push(testData)
+    stream.push(null)
+
+    getRawBody(stream, {
+      length: Infinity
+    }, function (err, buf) {
+      assert.ifError(err)
+      assert.ok(buf)
+      assert.strictEqual(buf.length, expectedLength)
+
+      var stream2 = new Readable()
+      stream2.push(testData)
+      stream2.push(null)
+
+      getRawBody(stream2, {
+        length: -1
+      }, function (err2, buf2) {
+        assert.ifError(err2)
+        assert.ok(buf2)
+        assert.strictEqual(buf2.length, expectedLength)
+        done()
+      })
+    })
+  })
+
   it('should work with {"test":"å"}', function (done) {
     // https://github.com/visionmedia/express/issues/1816
 


### PR DESCRIPTION
Invalid length values (Infinity, -Infinity, negative numbers, NaN) were not properly validated. parseInt(Infinity, 10) returns NaN, which would always fail length validation checks since NaN !== null is true, causing unexpected validation errors.

Add validation to ensure parsed length is finite and non-negative. Invalid values are now treated as null (no length validation), matching the intended behavior when length is not specified.

Add test to verify invalid length values are handled correctly.