### PR TITLE
test: add test for length as string number

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -186,6 +186,24 @@ describe('Raw Body', function () {
     })
   })
 
+  it('should handle length as string number', function (done) {
+    var testData = 'test'
+    var expectedLength = testData.length
+
+    var stream = new Readable()
+    stream.push(testData)
+    stream.push(null)
+
+    getRawBody(stream, {
+      length: String(expectedLength)
+    }, function (err, buf) {
+      assert.ifError(err)
+      assert.ok(buf)
+      assert.strictEqual(buf.length, expectedLength)
+      done()
+    })
+  })
+
   it('should work with {"test":"å"}', function (done) {
     // https://github.com/visionmedia/express/issues/1816
 


### PR DESCRIPTION
Verify that length option accepts string numbers (e.g. "4") which are parsed correctly by parseInt().