### PR TITLE
docs: enhance security reporting and disclosure procedures (#101)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,24 +1,56 @@
 # Security Policies and Procedures
 
-## Reporting a Bug
+This document outlines security procedures and general policies for the raw-body
+project.
 
-The `raw-body` team and community take all security bugs seriously. Thank you
-for improving the security of Express. We appreciate your efforts and
-responsible disclosure and will make every effort to acknowledge your
-contributions.
+- [Security Policies and Procedures](#security-policies-and-procedures)
+  - [Reporting a Bug or Security Vulnerability](#reporting-a-bug-or-security-vulnerability)
+    - [Reporting Security Bugs via GitHub Security Advisory](#reporting-security-bugs-via-github-security-advisory)
+    - [Third-Party Modules](#third-party-modules)
+  - [Disclosure Policy](#disclosure-policy)
+  - [Comments on this Policy](#comments-on-this-policy)
 
-Report security bugs by emailing the current owners of `raw-body`. This information
-can be found in the npm registry using the command `npm owner ls raw-body`.
-If unsure or unable to get the information from the above, open an issue
-in the [project issue tracker](https://github.com/stream-utils/raw-body/issues)
-asking for the current contact information.
+## Reporting a Bug or Security Vulnerability  
 
-To ensure the timely response to your report, please ensure that the entirety
-of the report is contained within the email body and not solely behind a web
-link or an attachment.
+The `raw-body` team and community take all security vulnerabilities seriously. 
+Thank you for improving the security of raw-body and related projects. 
+We appreciate your efforts in responsible disclosure and will make every effort 
+to acknowledge your contributions. 
 
-At least one owner will acknowledge your email within 48 hours, and will send a
-more detailed response within 48 hours indicating the next steps in handling
-your report. After the initial reply to your report, the owners will
-endeavor to keep you informed of the progress towards a fix and full
-announcement, and may ask for additional information or guidance.
+A member of the team will acknowledge your report as soon as possible. These timelines may extend when our triage volunteers are away on holiday, particularly at the end of the year.
+
+After the initial response to your report, the owners commit to keeping you informed
+about the progress toward a fix and the final announcement, and they may request additional
+information or clarification during the process.
+
+### Reporting Security Bugs via GitHub Security Advisory 
+
+The preferred way to report security vulnerabilities is through 
+[GitHub Security Advisories](https://github.com/advisories). 
+This allows us to collaborate on a fix while maintaining the 
+confidentiality of the report.  
+
+To report a vulnerability
+([docs](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)):  
+1. Visit the **Security** tab of the affected repository on GitHub.  
+2. Click **Report a vulnerability** and follow the provided steps.  
+
+### Third-Party Modules  
+
+If the security issue pertains to a third-party module, please report it to the maintainers of that module.  
+
+## Disclosure Policy
+
+When the raw-body team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    released as fast as possible to npm.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
* docs: enhance security reporting and disclosure procedures

Expanded the security policies and procedures section to include detailed reporting guidelines and disclosure policies.

* docs: remove ref about email



* docs: clarify acknowledgment timelines for security reports



---------