### PR TITLE
release 2.5.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
-unreleased
+2.5.3 / 2025-11-25
 ==================
+
   * deps: http-errors@2.0.1
     - deps: statuses@2.0.2
     - deps: use tilde notation for dependencies

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raw-body",
   "description": "Get and validate the raw body of a readable stream.",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",


### PR DESCRIPTION
## What's Changed
* ci: restore ci for v2 by @bjohansebas in https://github.com/stream-utils/raw-body/pull/127
* deps: use tilde notation for dependencies by @bjohansebas in https://github.com/stream-utils/raw-body/pull/126
* chore: remove history.md and security.md from being packaged on publish (#122) by @bjohansebas in https://github.com/stream-utils/raw-body/pull/129


**Full Changelog**: https://github.com/stream-utils/raw-body/compare/2.5.2...v2