### PR TITLE
chore: remove `iconv-lite` and use native `TextDecoder`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,12 @@ unreleased
 ==================
 
   * deps: remove `unpipe` and use native `stream.unpipe()`
+  * deps: remove `iconv-lite` and use native `TextDecoder`
+    - Breaking Change: supported encodings are now those of the
+      [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/#names-and-labels);
+      encodings outside the standard (e.g. UTF-32) now throw a 415 error
+    - Breaking Change: `utf-16` no longer detects a big-endian BOM and always
+      decodes as little-endian; use `utf-16be` for big-endian content
   * Breaking Change: Node.js 18 is the minimum supported version
 
 3.0.1 / 2025-09-03

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Options:
 - `encoding` - The encoding to use to decode the body into a string.
   By default, a `Buffer` instance will be returned when no encoding is specified.
   Most likely, you want `utf-8`, so setting `encoding` to `true` will decode as `utf-8`.
-  You can use any type of encoding supported by [iconv-lite](https://www.npmjs.org/package/iconv-lite#readme).
+  You can use any encoding supported by [`TextDecoder`](https://developer.mozilla.org/en-US/docs/Web/API/Encodings),
+  as defined by the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/#names-and-labels).
 
 You can also pass a string in place of options to just specify the encoding.
 
@@ -87,8 +88,7 @@ determination of the type of error returned.
 #### encoding.unsupported
 
 This error will occur when the `encoding` option is specified, but the value does
-not map to an encoding supported by the [iconv-lite](https://www.npmjs.org/package/iconv-lite#readme)
-module.
+not map to an encoding supported by [`TextDecoder`](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder).
 
 #### entity.too.large
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace getRawBody {
      * The encoding to use to decode the body into a string. By default, a
      * `Buffer` instance will be returned when no encoding is specified. Most
      * likely, you want `utf-8`, so setting encoding to `true` will decode as
-     * `utf-8`. You can use any type of encoding supported by `iconv-lite`.
+     * `utf-8`. You can use any encoding supported by `TextDecoder`.
      */
     encoding?: Encoding | null;
   }

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@
 const { AsyncResource } = require('async_hooks')
 const bytes = require('bytes')
 const createError = require('http-errors')
-const iconv = require('iconv-lite')
 
 /**
  * Module exports.
@@ -23,13 +22,6 @@ const iconv = require('iconv-lite')
  */
 
 module.exports = getRawBody
-
-/**
- * Module variables.
- * @private
- */
-
-const ICONV_ENCODING_MESSAGE_REGEXP = /^Encoding not recognized: /
 
 /**
  * Get the decoder for a given encoding.
@@ -42,11 +34,8 @@ function getDecoder (encoding) {
   if (!encoding) return null
 
   try {
-    return iconv.getDecoder(encoding)
+    return new TextDecoder(encoding)
   } catch (e) {
-    // error getting decoder
-    if (!ICONV_ENCODING_MESSAGE_REGEXP.test(e.message)) throw e
-
     // the encoding was not found
     throw createError(415, 'specified encoding unsupported', {
       encoding,
@@ -263,7 +252,9 @@ function readStream (stream, encoding, length, limit, callback) {
         type: 'entity.too.large'
       }))
     } else if (decoder) {
-      buffer += decoder.write(chunk)
+      // streams1 may emit string chunks
+      const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
+      buffer += decoder.decode(buf, { stream: true })
     } else {
       buffer.push(chunk)
     }
@@ -282,7 +273,7 @@ function readStream (stream, encoding, length, limit, callback) {
       }))
     } else {
       const string = decoder
-        ? buffer + (decoder.end() || '')
+        ? buffer + decoder.decode()
         : Buffer.concat(buffer)
       done(null, string)
     }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "repository": "stream-utils/raw-body",
   "dependencies": {
     "bytes": "^3.1.2",
-    "http-errors": "^2.0.0",
-    "iconv-lite": "^0.7.0"
+    "http-errors": "^2.0.0"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^5.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -366,11 +366,10 @@ describe('Raw Body', function () {
       })
     })
 
-    it('should decode UTF-16 string (BE BOM)', function (done) {
-      // BOM makes this BE
+    it('should decode UTF-16BE string (BE BOM)', function (done) {
       const stream = createStream(Buffer.from('feff00bf004300f3006d006f002000650073007400e10073003f', 'hex'))
       const string = '¿Cómo estás?'
-      getRawBody(stream, 'utf-16', function (err, str) {
+      getRawBody(stream, 'utf-16be', function (err, str) {
         assert.ifError(err)
         assert.strictEqual(str, string)
         done()
@@ -388,24 +387,13 @@ describe('Raw Body', function () {
       })
     })
 
-    it('should decode UTF-32 string (LE BOM)', function (done) {
-      // BOM makes this LE
+    it('should reject UTF-32 as unsupported', function (done) {
+      // UTF-32 is not part of the WHATWG Encoding Standard
       const stream = createStream(Buffer.from('fffe0000bf00000043000000f30000006d0000006f00000020000000650000007300000074000000e1000000730000003f000000', 'hex'))
-      const string = '¿Cómo estás?'
-      getRawBody(stream, 'utf-32', function (err, str) {
-        assert.ifError(err)
-        assert.strictEqual(str, string)
-        done()
-      })
-    })
-
-    it('should decode UTF-32 string (BE BOM)', function (done) {
-      // BOM makes this BE
-      const stream = createStream(Buffer.from('0000feff000000bf00000043000000f30000006d0000006f00000020000000650000007300000074000000e1000000730000003f', 'hex'))
-      const string = '¿Cómo estás?'
-      getRawBody(stream, 'utf-32', function (err, str) {
-        assert.ifError(err)
-        assert.strictEqual(str, string)
+      getRawBody(stream, 'utf-32', function (err) {
+        assert.ok(err)
+        assert.strictEqual(err.status, 415)
+        assert.strictEqual(err.type, 'encoding.unsupported')
         done()
       })
     })


### PR DESCRIPTION
- Breaking Change: supported encodings are now those of the WHATWG Encoding Standard; unsupported encodings will throw a 415 error
