### PR TITLE
feat: support reading from WHATWG ReadableStreams

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,23 @@
 unreleased
 ==================
 
+  * Add support for WHATWG `ReadableStream` (web streams): `fetch`
+    `Request`/`Response` bodies, `Blob.stream()`, `TransformStream`
+    readables, and `Readable.toWeb()` bridges
+    - streams already locked, read, or cancelled error with a 500
+      `stream.not.readable`
+    - client aborts are mapped to the same 400 `request.aborted` error
+      as node streams, with the original error in `cause`
+    - string chunks are accepted without an encoding (UTF-8 `Buffer`);
+      combined with `encoding` or `decoder` they error with a 500
+      `stream.encoding.set`, since the stream is already decoded
+    - non-byte chunks (e.g. `ArrayBuffer`) error with a `TypeError`
+    - on error the reader lock is released, but the stream is not
+      cancelled; disposing it is up to the caller
+  * Fix process crash when a custom `decoder` throws while reading
+    node streams
+  * Fix process crash on legacy streams1 emitting string chunks with
+    no encoding set; this now errors through the callback
   * deps: remove `unpipe` and use native `stream.unpipe()`
   * deps: remove `iconv-lite` and use native `TextDecoder`
     - Breaking Change: supported encodings are now those of the

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,7 @@ unreleased
     - client aborts are mapped to the same 400 `request.aborted` error
       as node streams, with the original error in `cause`
     - string chunks are accepted without an encoding (UTF-8 `Buffer`);
-      combined with `encoding` or `decoder` they error with a 500
+      combined with an encoding they error with a 500
       `stream.encoding.set`, since the stream is already decoded
     - non-byte chunks (e.g. `ArrayBuffer`) error with a `TypeError`
     - on error the reader lock is released, but the stream is not

--- a/README.md
+++ b/README.md
@@ -143,10 +143,9 @@ emitted more bytes.
 This error will occur when the given stream has an encoding set on it, making it
 a decoded stream. The stream should not have an encoding set and is expected to
 emit `Buffer` objects. For web streams, this occurs when the stream yields
-string chunks while the `encoding` or `decoder` option is used — the stream is
-already decoded, so decoding it again would corrupt the data. (Without those
-options, string chunks are accepted and encoded as UTF-8 into the returned
-`Buffer`.)
+string chunks while an encoding is set — the stream is already decoded, so
+decoding it again would corrupt the data. (Without an encoding, string
+chunks are accepted and encoded as UTF-8 into the returned `Buffer`.)
 
 #### stream.not.readable
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,11 @@ emitted more bytes.
 
 This error will occur when the given stream has an encoding set on it, making it
 a decoded stream. The stream should not have an encoding set and is expected to
-emit `Buffer` objects.
+emit `Buffer` objects. For web streams, this occurs when the stream yields
+string chunks while the `encoding` or `decoder` option is used — the stream is
+already decoded, so decoding it again would corrupt the data. (Without those
+options, string chunks are accepted and encoded as UTF-8 into the returned
+`Buffer`.)
 
 #### stream.not.readable
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Options:
   The returned decoder must implement `write(chunk)` and `end()`, both
   returning a string, which is the interface of
   [iconv-lite](https://www.npmjs.org/package/iconv-lite#readme)'s `getDecoder`,
-  so it can be passed directly to decode encodings outside the WHATWG standard:
+  so it can be passed directly to decode encodings outside the WHATWG standard.
+  The chunk is only valid during the `write(chunk)` call: a decoder that
+  keeps pending bytes across calls must copy them, as `TextDecoder` and
+  iconv-lite do — the underlying memory may be reused afterwards:
 
 <!-- eslint-disable no-undef -->
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ you want to keep the socket open for future requests. For streams
 that use file descriptors, you should `stream.destroy()` or
 `stream.close()` to prevent leaks.
 
-For web streams, the reader lock is released both on success and on
-error, but the stream is never canceled, so on error you are
-responsible for disposing it, for example with `stream.cancel()`.
+For web streams, any reader lock this module acquired is released both
+on success and on error, but the stream is never canceled, so on error
+you are responsible for disposing it, for example with `stream.cancel()`.
 
 ## Errors
 
@@ -110,6 +110,8 @@ otherwise an error created by this module, which has the following attributes:
   * `encoding` - the invalid encoding
   * `status` and `statusCode` - the corresponding status code for the error
   * `type` - the error type
+  * `cause` - the underlying error, when the error wraps another one
+    (for example an aborted web stream)
 
 ### Types
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ emit `Buffer` objects.
 #### stream.not.readable
 
 This error will occur when the given stream is not readable, or, for a web
-stream, when it is already locked to another reader.
+stream, when it is already locked to another reader, already read, or
+cancelled.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ var getRawBody = require('raw-body')
 
 **Returns a promise if no callback specified.**
 
+The `stream` argument can be a Node.js readable stream (like an HTTP request)
+or a [WHATWG `ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+(like the body of a `fetch` `Response`).
+
 Options:
 
 - `length` - The length of the stream.
@@ -86,6 +90,10 @@ For HTTP requests, you may need to finish consuming the stream if
 you want to keep the socket open for future requests. For streams
 that use file descriptors, you should `stream.destroy()` or
 `stream.close()` to prevent leaks.
+
+For web streams, the reader lock is released both on success and on
+error, but the stream is never canceled, so on error you are
+responsible for disposing it, for example with `stream.cancel()`.
 
 ## Errors
 
@@ -133,7 +141,8 @@ emit `Buffer` objects.
 
 #### stream.not.readable
 
-This error will occur when the given stream is not readable.
+This error will occur when the given stream is not readable, or, for a web
+stream, when it is already locked to another reader.
 
 ## Examples
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 declare namespace getRawBody {
   export type Encoding = string | true;
 
+  export type RawBodyStream = NodeJS.ReadableStream | ReadableStream<Uint8Array | string>;
+
   export interface Options {
     /**
      * The expected length of the stream.
@@ -68,29 +70,29 @@ declare namespace getRawBody {
  * limit. Ideal for parsing request bodies.
  */
 declare function getRawBody(
-  stream: NodeJS.ReadableStream,
+  stream: getRawBody.RawBodyStream,
   callback: (err: getRawBody.RawBodyError, body: Buffer) => void
 ): void;
 
 declare function getRawBody(
-  stream: NodeJS.ReadableStream,
+  stream: getRawBody.RawBodyStream,
   options: (getRawBody.Options & { encoding: getRawBody.Encoding }) | getRawBody.Encoding,
   callback: (err: getRawBody.RawBodyError, body: string) => void
 ): void;
 
 declare function getRawBody(
-  stream: NodeJS.ReadableStream,
+  stream: getRawBody.RawBodyStream,
   options: getRawBody.Options,
   callback: (err: getRawBody.RawBodyError, body: Buffer) => void
 ): void;
 
 declare function getRawBody(
-  stream: NodeJS.ReadableStream,
+  stream: getRawBody.RawBodyStream,
   options: (getRawBody.Options & { encoding: getRawBody.Encoding }) | getRawBody.Encoding
 ): Promise<string>;
 
 declare function getRawBody(
-  stream: NodeJS.ReadableStream,
+  stream: getRawBody.RawBodyStream,
   options?: getRawBody.Options
 ): Promise<Buffer>;
 

--- a/index.js
+++ b/index.js
@@ -398,9 +398,13 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   }
 
   function onError (err) {
-    // map aborts to the same error the node path produces
-    if (err && err.name === 'AbortError') {
+    // map aborts to the same error the node path produces.
+    // Readable.toWeb error the stream with an
+    // AbortError; an aborted node request bridged with
+    // Readable.toWeb surfaces its ECONNRESET instead
+    if (err && (err.name === 'AbortError' || err.code === 'ECONNRESET')) {
       return done(createError(400, 'request aborted', {
+        cause: err,
         code: 'ECONNABORTED',
         expected: length,
         length,

--- a/index.js
+++ b/index.js
@@ -305,6 +305,24 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
 }
 
 /**
+ * Convert a web stream chunk to a Buffer.
+ *
+ * @param {*} chunk
+ * @private
+ */
+
+function toBuffer (chunk) {
+  if (typeof chunk === 'string') return Buffer.from(chunk)
+  if (Buffer.isBuffer(chunk)) return chunk
+
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+  }
+
+  throw new TypeError('stream chunks must be Uint8Array or string')
+}
+
+/**
  * Read the data from a web ReadableStream.
  *
  * @param {ReadableStream} stream
@@ -390,14 +408,12 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
     let chunk
 
     try {
-      chunk = typeof result.value === 'string'
-        ? Buffer.from(result.value)
-        : result.value
-
-      received += chunk.length
+      chunk = toBuffer(result.value)
     } catch (err) {
       return done(err)
     }
+
+    received += chunk.length
 
     if (limit !== null && received > limit) {
       done(createError(413, 'request entity too large', {
@@ -408,9 +424,7 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
     } else {
       try {
         if (decoder) {
-          buffer += decoder.write(Buffer.isBuffer(chunk)
-            ? chunk
-            : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+          buffer += decoder.write(chunk)
         } else {
           buffer.push(chunk)
         }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@
  */
 
 const { AsyncResource } = require('async_hooks')
+const { isDisturbed } = require('stream')
 const bytes = require('bytes')
 const createError = require('http-errors')
 
@@ -350,7 +351,9 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
     }))
   }
 
-  if (stream.locked) {
+  // reject streams locked to another reader, and streams
+  // already read or cancelled (disturbed)
+  if (stream.locked || isDisturbed(stream)) {
     return fail(createError(500, 'stream is not readable', {
       type: 'stream.not.readable'
     }))
@@ -381,6 +384,17 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   }
 
   function onError (err) {
+    // map aborts to the same error the node path produces
+    if (err && err.name === 'AbortError') {
+      return done(createError(400, 'request aborted', {
+        code: 'ECONNABORTED',
+        expected: length,
+        length,
+        received,
+        type: 'request.aborted'
+      }))
+    }
+
     // a web stream may error with a falsy reason, e.g.
     // controller.error() without arguments
     done(err || new Error('stream error'))

--- a/index.js
+++ b/index.js
@@ -58,6 +58,114 @@ function getDecoder (encoding, createDecoder) {
 }
 
 /**
+ * Create a 413 entity too large error. The properties differ
+ * between the early length check and the streamed limit check.
+ *
+ * @param {object} props
+ * @private
+ */
+
+function entityTooLargeError (props) {
+  props.type = 'entity.too.large'
+  return createError(413, 'request entity too large', props)
+}
+
+/**
+ * Create a 400 request aborted error.
+ *
+ * @param {number} length
+ * @param {number} received
+ * @param {Error} [cause]
+ * @private
+ */
+
+function abortedError (length, received, cause) {
+  const err = createError(400, 'request aborted', {
+    code: 'ECONNABORTED',
+    expected: length,
+    length,
+    received,
+    type: 'request.aborted'
+  })
+
+  if (cause !== undefined) {
+    err.cause = cause
+  }
+
+  return err
+}
+
+/**
+ * Create a 400 size mismatch error.
+ *
+ * @param {number} length
+ * @param {number} received
+ * @private
+ */
+
+function sizeMismatchError (length, received) {
+  return createError(400, 'request size did not match content length', {
+    expected: length,
+    length,
+    received,
+    type: 'request.size.invalid'
+  })
+}
+
+/**
+ * Create a 500 not readable error.
+ *
+ * @private
+ */
+
+function notReadableError () {
+  return createError(500, 'stream is not readable', {
+    type: 'stream.not.readable'
+  })
+}
+
+/**
+ * Create a 500 encoding set error.
+ *
+ * @private
+ */
+
+function encodingSetError () {
+  return createError(500, 'stream encoding should not be set', {
+    type: 'stream.encoding.set'
+  })
+}
+
+/**
+ * Validate the total received length and assemble the body.
+ *
+ * @param {object} decoder
+ * @param {string|Array} buffer
+ * @param {number} length
+ * @param {number} received
+ * @param {function} done
+ * @private
+ */
+
+function finish (decoder, buffer, length, received, done) {
+  if (length !== null && received !== length) {
+    return done(sizeMismatchError(length, received))
+  }
+
+  let string
+
+  try {
+    string = decoder
+      ? buffer + (decoder.end() || '')
+      : Buffer.concat(buffer)
+  } catch (err) {
+    return done(err)
+  }
+
+  done(null, string)
+}
+
+/**
  * Get the raw body of a stream (typically HTTP).
  *
  * @param {object} stream
@@ -171,26 +279,17 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
   // note: we intentionally leave the stream paused,
   // so users should handle the stream themselves.
   if (limit !== null && length !== null && length > limit) {
-    return done(createError(413, 'request entity too large', {
-      expected: length,
-      length,
-      limit,
-      type: 'entity.too.large'
-    }))
+    return done(entityTooLargeError({ expected: length, length, limit }))
   }
 
   // assert the stream encoding is buffer.
   if (stream.readableEncoding) {
     // developer error
-    return done(createError(500, 'stream encoding should not be set', {
-      type: 'stream.encoding.set'
-    }))
+    return done(encodingSetError())
   }
 
   if (typeof stream.readable !== 'undefined' && !stream.readable) {
-    return done(createError(500, 'stream is not readable', {
-      type: 'stream.not.readable'
-    }))
+    return done(notReadableError())
   }
 
   let received = 0
@@ -248,13 +347,7 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
   function onAborted () {
     if (complete) return
 
-    done(createError(400, 'request aborted', {
-      code: 'ECONNABORTED',
-      expected: length,
-      length,
-      received,
-      type: 'request.aborted'
-    }))
+    done(abortedError(length, received))
   }
 
   function onData (chunk) {
@@ -263,11 +356,7 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
     received += chunk.length
 
     if (limit !== null && received > limit) {
-      done(createError(413, 'request entity too large', {
-        limit,
-        received,
-        type: 'entity.too.large'
-      }))
+      done(entityTooLargeError({ limit, received }))
     } else if (decoder) {
       // streams1 may emit string chunks
       const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
@@ -286,26 +375,7 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
     if (complete) return
     if (err) return done(err)
 
-    if (length !== null && received !== length) {
-      done(createError(400, 'request size did not match content length', {
-        expected: length,
-        length,
-        received,
-        type: 'request.size.invalid'
-      }))
-    } else {
-      let string
-
-      try {
-        string = decoder
-          ? buffer + (decoder.end() || '')
-          : Buffer.concat(buffer)
-      } catch (err) {
-        return done(err)
-      }
-
-      done(null, string)
-    }
+    finish(decoder, buffer, length, received, done)
   }
 
   function cleanup () {
@@ -354,23 +424,16 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   let reader = null
 
   // check the length and limit options.
-  // note: we release the reader lock but do not cancel the stream,
-  // so users should handle the stream themselves.
+  // note: on error the reader lock is released but the stream is
+  // not cancelled, so users should handle the stream themselves.
   if (limit !== null && length !== null && length > limit) {
-    return fail(createError(413, 'request entity too large', {
-      expected: length,
-      length,
-      limit,
-      type: 'entity.too.large'
-    }))
+    return fail(entityTooLargeError({ expected: length, length, limit }))
   }
 
   // reject streams locked to another reader, and streams
   // already read or cancelled (disturbed)
   if (stream.locked || isDisturbed(stream)) {
-    return fail(createError(500, 'stream is not readable', {
-      type: 'stream.not.readable'
-    }))
+    return fail(notReadableError())
   }
 
   let received = 0
@@ -398,19 +461,12 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   }
 
   function onError (err) {
-    // map aborts to the same error the node path produces.
-    // Readable.toWeb error the stream with an
+    // map aborts to the same error the node path produces:
+    // undici and Readable.toWeb error the stream with an
     // AbortError; an aborted node request bridged with
     // Readable.toWeb surfaces its ECONNRESET instead
     if (err && (err.name === 'AbortError' || err.code === 'ECONNRESET')) {
-      return done(createError(400, 'request aborted', {
-        cause: err,
-        code: 'ECONNABORTED',
-        expected: length,
-        length,
-        received,
-        type: 'request.aborted'
-      }))
+      return done(abortedError(length, received, err))
     }
 
     if (err instanceof Error) {
@@ -440,14 +496,12 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   }
 
   function onRead (result) {
-    if (result.done) return onEnd()
+    if (result.done) return finish(decoder, buffer, length, received, done)
 
     // a stream of strings is already decoded, so decoding it
     // again with the declared encoding would corrupt the data
     if (decoder && typeof result.value === 'string') {
-      return done(createError(500, 'stream encoding should not be set', {
-        type: 'stream.encoding.set'
-      }))
+      return done(encodingSetError())
     }
 
     let chunk
@@ -461,11 +515,7 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
     received += chunk.length
 
     if (limit !== null && received > limit) {
-      done(createError(413, 'request entity too large', {
-        limit,
-        received,
-        type: 'entity.too.large'
-      }))
+      done(entityTooLargeError({ limit, received }))
     } else {
       try {
         if (decoder) {
@@ -483,29 +533,6 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
       }
 
       read()
-    }
-  }
-
-  function onEnd () {
-    if (length !== null && received !== length) {
-      done(createError(400, 'request size did not match content length', {
-        expected: length,
-        length,
-        received,
-        type: 'request.size.invalid'
-      }))
-    } else {
-      let string
-
-      try {
-        string = decoder
-          ? buffer + (decoder.end() || '')
-          : Buffer.concat(buffer)
-      } catch (err) {
-        return done(err)
-      }
-
-      done(null, string)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -460,9 +460,14 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
     } else {
       try {
         if (decoder) {
+          // the decoder consumes the chunk immediately,
+          // so the zero-copy view is safe here
           buffer += decoder.write(chunk)
         } else {
-          buffer.push(chunk)
+          // copy: the producer may legally reuse the chunk's
+          // memory after enqueuing it, and this view is kept
+          // until the stream ends
+          buffer.push(Buffer.from(chunk))
         }
       } catch (err) {
         return done(err)

--- a/index.js
+++ b/index.js
@@ -113,10 +113,12 @@ function getRawBody (stream, options, callback) {
     ? parseInt(opts.length, 10)
     : null
 
-  // select the reader for the stream type
-  const read = typeof stream.getReader === 'function'
-    ? readWebStream
-    : readStream
+  // select the reader for the stream type.
+  // node streams take precedence, so objects exposing both
+  // interfaces keep the historical duck-typed behavior
+  const read = typeof stream.on === 'function'
+    ? readStream
+    : readWebStream
 
   if (done) {
     // classic callback style

--- a/index.js
+++ b/index.js
@@ -359,7 +359,13 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
     // promise assimilation guarantees the handlers run
     // asynchronously and at most once, even for a reader
     // that misbehaves (ECMA-262 PromiseResolve)
-    Promise.resolve(reader.read()).then(onRead, done)
+    Promise.resolve(reader.read()).then(onRead, onError)
+  }
+
+  function onError (err) {
+    // a web stream may error with a falsy reason, e.g.
+    // controller.error() without arguments
+    done(err || new Error('stream error'))
   }
 
   function fail (err) {
@@ -381,11 +387,17 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   function onRead (result) {
     if (result.done) return onEnd()
 
-    const chunk = typeof result.value === 'string'
-      ? Buffer.from(result.value)
-      : result.value
+    let chunk
 
-    received += chunk.length
+    try {
+      chunk = typeof result.value === 'string'
+        ? Buffer.from(result.value)
+        : result.value
+
+      received += chunk.length
+    } catch (err) {
+      return done(err)
+    }
 
     if (limit !== null && received > limit) {
       done(createError(413, 'request entity too large', {

--- a/index.js
+++ b/index.js
@@ -413,9 +413,14 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
       }))
     }
 
-    // a web stream may error with a falsy reason, e.g.
-    // controller.error() without arguments
-    done(err || new Error('stream error'))
+    if (err instanceof Error) {
+      return done(err)
+    }
+
+    // a web stream may error with any value — a string reason,
+    // an object, or nothing at all (controller.error() without
+    // arguments): normalize, so callers always get an Error
+    done(new Error('stream error', { cause: err }))
   }
 
   function fail (err) {

--- a/index.js
+++ b/index.js
@@ -72,7 +72,8 @@ function getRawBody (stream, options, callback) {
   // light validation
   if (stream === undefined) {
     throw new TypeError('argument stream is required')
-  } else if (typeof stream !== 'object' || stream === null || typeof stream.on !== 'function') {
+  } else if (typeof stream !== 'object' || stream === null ||
+    (typeof stream.on !== 'function' && typeof stream.getReader !== 'function')) {
     throw new TypeError('argument stream must be a stream')
   }
 
@@ -111,13 +112,18 @@ function getRawBody (stream, options, callback) {
     ? parseInt(opts.length, 10)
     : null
 
+  // select the reader for the stream type
+  const read = typeof stream.getReader === 'function'
+    ? readWebStream
+    : readStream
+
   if (done) {
     // classic callback style
-    return readStream(stream, encoding, length, limit, opts.decoder, AsyncResource.bind(done, done.name || 'bound-anonymous-fn', null))
+    return read(stream, encoding, length, limit, opts.decoder, AsyncResource.bind(done, done.name || 'bound-anonymous-fn', null))
   }
 
   return new Promise(function executor (resolve, reject) {
-    readStream(stream, encoding, length, limit, opts.decoder, function onRead (err, buf) {
+    read(stream, encoding, length, limit, opts.decoder, function onRead (err, buf) {
       if (err) return reject(err)
       resolve(buf)
     })
@@ -295,5 +301,142 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
     stream.removeListener('end', onEnd)
     stream.removeListener('error', onEnd)
     stream.removeListener('close', cleanup)
+  }
+}
+
+/**
+ * Read the data from a web ReadableStream.
+ *
+ * @param {ReadableStream} stream
+ * @param {string} encoding
+ * @param {number} length
+ * @param {number} limit
+ * @param {function} createDecoder
+ * @param {function} callback
+ * @private
+ */
+
+function readWebStream (stream, encoding, length, limit, createDecoder, callback) {
+  let buffer
+  let complete = false
+  let reader = null
+  let sync = true
+
+  // check the length and limit options.
+  // note: we release the reader lock but do not cancel the stream,
+  // so users should handle the stream themselves.
+  if (limit !== null && length !== null && length > limit) {
+    return done(createError(413, 'request entity too large', {
+      expected: length,
+      length,
+      limit,
+      type: 'entity.too.large'
+    }))
+  }
+
+  if (stream.locked) {
+    return done(createError(500, 'stream is not readable', {
+      type: 'stream.not.readable'
+    }))
+  }
+
+  let received = 0
+  let decoder
+
+  try {
+    decoder = getDecoder(encoding, createDecoder)
+  } catch (err) {
+    return done(err)
+  }
+
+  buffer = decoder
+    ? ''
+    : []
+
+  reader = stream.getReader()
+
+  // mark sync section complete
+  sync = false
+
+  reader.read().then(onRead, onError)
+
+  function done () {
+    const args = new Array(arguments.length)
+
+    // copy arguments
+    for (let i = 0; i < args.length; i++) {
+      args[i] = arguments[i]
+    }
+
+    // mark complete
+    complete = true
+
+    if (sync) {
+      process.nextTick(invokeCallback)
+    } else {
+      invokeCallback()
+    }
+
+    function invokeCallback () {
+      buffer = null
+
+      if (reader) {
+        // release the stream, so users can handle the rest themselves
+        reader.releaseLock()
+      }
+
+      callback.apply(null, args)
+    }
+  }
+
+  function onRead (result) {
+    if (complete) return
+    if (result.done) return onEnd()
+
+    const chunk = typeof result.value === 'string'
+      ? Buffer.from(result.value)
+      : result.value
+
+    received += chunk.length
+
+    if (limit !== null && received > limit) {
+      done(createError(413, 'request entity too large', {
+        limit,
+        received,
+        type: 'entity.too.large'
+      }))
+    } else {
+      if (decoder) {
+        buffer += decoder.write(Buffer.isBuffer(chunk)
+          ? chunk
+          : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+      } else {
+        buffer.push(chunk)
+      }
+
+      reader.read().then(onRead, onError)
+    }
+  }
+
+  function onEnd () {
+    if (length !== null && received !== length) {
+      done(createError(400, 'request size did not match content length', {
+        expected: length,
+        length,
+        received,
+        type: 'request.size.invalid'
+      }))
+    } else {
+      const string = decoder
+        ? buffer + (decoder.end() || '')
+        : Buffer.concat(buffer)
+      done(null, string)
+    }
+  }
+
+  function onError (err) {
+    if (complete) return
+
+    done(err)
   }
 }

--- a/index.js
+++ b/index.js
@@ -144,8 +144,7 @@ function encodingSetError () {
  * @param {number} length
  * @param {number} received
  * @param {function} done
- * @param {number} [total] exact buffered byte count, when known,
- *   so Buffer.concat can skip re-summing the chunk lengths
+ * @param {number} [total] exact byte count, when known
  * @private
  */
 
@@ -456,18 +455,16 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   read()
 
   function read () {
-    // note: not .catch — onError must only see read() rejections;
-    // a throw from the user callback inside onRead would otherwise
-    // be misread as a stream error and invoke the callback again
+    // not .catch: onError must only see read() rejections,
+    // never throws from the user callback inside onRead
     reader.read().then(onRead, onError)
   }
 
   function onError (err) {
-    // map aborts to the same error the node path produces:
-    // undici and Readable.toWeb error the stream with an
-    // AbortError; an aborted node request bridged with
-    // Readable.toWeb surfaces its ECONNRESET instead
-    if (err && (err.name === 'AbortError' || err.code === 'ECONNRESET')) {
+    // map aborts (undici's AbortError, node http's ECONNRESET
+    // 'aborted') like the node path; other resets pass through
+    if (err && (err.name === 'AbortError' ||
+      (err.code === 'ECONNRESET' && err.message === 'aborted'))) {
       return done(abortedError(length, received, err))
     }
 
@@ -475,9 +472,8 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
       return done(err)
     }
 
-    // a web stream may error with any value — a string reason,
-    // an object, or nothing at all (controller.error() without
-    // arguments): normalize, so callers always get an Error
+    // a web stream may error with any value, or none at all:
+    // normalize, so callers always get an Error
     done(new Error('stream error', { cause: err }))
   }
 
@@ -498,8 +494,7 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   }
 
   function onRead (result) {
-    // received counts exact bytes on this path (string chunks
-    // are converted before counting), unlike the node path
+    // received is an exact byte count on this path
     if (result.done) return finish(decoder, buffer, length, received, done, received)
 
     // a stream of strings is already decoded, so decoding it
@@ -523,13 +518,10 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
     } else {
       try {
         if (decoder) {
-          // the decoder consumes the chunk immediately,
-          // so the zero-copy view is safe here
+          // consumed immediately: the zero-copy view is safe
           buffer += decoder.write(chunk)
         } else {
-          // copy: the producer may legally reuse the chunk's
-          // memory after enqueuing it, and this view is kept
-          // until the stream ends
+          // copy: the producer may reuse the chunk's memory
           buffer.push(Buffer.from(chunk))
         }
       } catch (err) {

--- a/index.js
+++ b/index.js
@@ -391,10 +391,10 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   read()
 
   function read () {
-    // promise assimilation guarantees the handlers run
-    // asynchronously and at most once, even for a reader
-    // that misbehaves (ECMA-262 PromiseResolve)
-    Promise.resolve(reader.read()).then(onRead, onError)
+    // note: not .catch — onError must only see read() rejections;
+    // a throw from the user callback inside onRead would otherwise
+    // be misread as a stream error and invoke the callback again
+    reader.read().then(onRead, onError)
   }
 
   function onError (err) {

--- a/index.js
+++ b/index.js
@@ -271,7 +271,12 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
     } else if (decoder) {
       // streams1 may emit string chunks
       const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
-      buffer += decoder.write(buf)
+
+      try {
+        buffer += decoder.write(buf)
+      } catch (err) {
+        done(err)
+      }
     } else {
       buffer.push(chunk)
     }
@@ -289,9 +294,16 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
         type: 'request.size.invalid'
       }))
     } else {
-      const string = decoder
-        ? buffer + (decoder.end() || '')
-        : Buffer.concat(buffer)
+      let string
+
+      try {
+        string = decoder
+          ? buffer + (decoder.end() || '')
+          : Buffer.concat(buffer)
+      } catch (err) {
+        return done(err)
+      }
+
       done(null, string)
     }
   }
@@ -420,6 +432,14 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
 
   function onRead (result) {
     if (result.done) return onEnd()
+
+    // a stream of strings is already decoded, so decoding it
+    // again with the declared encoding would corrupt the data
+    if (decoder && typeof result.value === 'string') {
+      return done(createError(500, 'stream encoding should not be set', {
+        type: 'stream.encoding.set'
+      }))
+    }
 
     let chunk
 

--- a/index.js
+++ b/index.js
@@ -144,10 +144,12 @@ function encodingSetError () {
  * @param {number} length
  * @param {number} received
  * @param {function} done
+ * @param {number} [total] exact buffered byte count, when known,
+ *   so Buffer.concat can skip re-summing the chunk lengths
  * @private
  */
 
-function finish (decoder, buffer, length, received, done) {
+function finish (decoder, buffer, length, received, done, total) {
   if (length !== null && received !== length) {
     return done(sizeMismatchError(length, received))
   }
@@ -157,7 +159,7 @@ function finish (decoder, buffer, length, received, done) {
   try {
     string = decoder
       ? buffer + (decoder.end() || '')
-      : Buffer.concat(buffer)
+      : Buffer.concat(buffer, total)
   } catch (err) {
     return done(err)
   }
@@ -496,7 +498,9 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   }
 
   function onRead (result) {
-    if (result.done) return finish(decoder, buffer, length, received, done)
+    // received counts exact bytes on this path (string chunks
+    // are converted before counting), unlike the node path
+    if (result.done) return finish(decoder, buffer, length, received, done, received)
 
     // a stream of strings is already decoded, so decoding it
     // again with the declared encoding would corrupt the data

--- a/index.js
+++ b/index.js
@@ -318,15 +318,13 @@ function readStream (stream, encoding, length, limit, createDecoder, callback) {
 
 function readWebStream (stream, encoding, length, limit, createDecoder, callback) {
   let buffer
-  let complete = false
   let reader = null
-  let sync = true
 
   // check the length and limit options.
   // note: we release the reader lock but do not cancel the stream,
   // so users should handle the stream themselves.
   if (limit !== null && length !== null && length > limit) {
-    return done(createError(413, 'request entity too large', {
+    return fail(createError(413, 'request entity too large', {
       expected: length,
       length,
       limit,
@@ -335,7 +333,7 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   }
 
   if (stream.locked) {
-    return done(createError(500, 'stream is not readable', {
+    return fail(createError(500, 'stream is not readable', {
       type: 'stream.not.readable'
     }))
   }
@@ -346,7 +344,7 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
   try {
     decoder = getDecoder(encoding, createDecoder)
   } catch (err) {
-    return done(err)
+    return fail(err)
   }
 
   buffer = decoder
@@ -355,42 +353,32 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
 
   reader = stream.getReader()
 
-  // mark sync section complete
-  sync = false
+  read()
 
-  reader.read().then(onRead, onError)
+  function read () {
+    // promise assimilation guarantees the handlers run
+    // asynchronously and at most once, even for a reader
+    // that misbehaves (ECMA-262 PromiseResolve)
+    Promise.resolve(reader.read()).then(onRead, done)
+  }
 
-  function done () {
-    const args = new Array(arguments.length)
+  function fail (err) {
+    // defer, so the callback is never invoked synchronously
+    process.nextTick(done, err)
+  }
 
-    // copy arguments
-    for (let i = 0; i < args.length; i++) {
-      args[i] = arguments[i]
+  function done (err, string) {
+    buffer = null
+
+    if (reader) {
+      // release the stream, so users can handle the rest themselves
+      reader.releaseLock()
     }
 
-    // mark complete
-    complete = true
-
-    if (sync) {
-      process.nextTick(invokeCallback)
-    } else {
-      invokeCallback()
-    }
-
-    function invokeCallback () {
-      buffer = null
-
-      if (reader) {
-        // release the stream, so users can handle the rest themselves
-        reader.releaseLock()
-      }
-
-      callback.apply(null, args)
-    }
+    callback(err, string)
   }
 
   function onRead (result) {
-    if (complete) return
     if (result.done) return onEnd()
 
     const chunk = typeof result.value === 'string'
@@ -406,15 +394,19 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
         type: 'entity.too.large'
       }))
     } else {
-      if (decoder) {
-        buffer += decoder.write(Buffer.isBuffer(chunk)
-          ? chunk
-          : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
-      } else {
-        buffer.push(chunk)
+      try {
+        if (decoder) {
+          buffer += decoder.write(Buffer.isBuffer(chunk)
+            ? chunk
+            : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+        } else {
+          buffer.push(chunk)
+        }
+      } catch (err) {
+        return done(err)
       }
 
-      reader.read().then(onRead, onError)
+      read()
     }
   }
 
@@ -427,16 +419,17 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
         type: 'request.size.invalid'
       }))
     } else {
-      const string = decoder
-        ? buffer + (decoder.end() || '')
-        : Buffer.concat(buffer)
+      let string
+
+      try {
+        string = decoder
+          ? buffer + (decoder.end() || '')
+          : Buffer.concat(buffer)
+      } catch (err) {
+        return done(err)
+      }
+
       done(null, string)
     }
-  }
-
-  function onError (err) {
-    if (complete) return
-
-    done(err)
   }
 }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,15 @@ const bytes = require('bytes')
 const createError = require('http-errors')
 
 /**
+ * Check if a value is an Error.
+ * @private
+ */
+
+const isError = typeof Error.isError === 'function'
+  ? Error.isError
+  : function (err) { return err instanceof Error }
+
+/**
  * Module exports.
  * @public
  */
@@ -468,7 +477,7 @@ function readWebStream (stream, encoding, length, limit, createDecoder, callback
       return done(abortedError(length, received, err))
     }
 
-    if (err instanceof Error) {
+    if (isError(err)) {
       return done(err)
     }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
   "engines": {
     "node": ">=18"  
   },
+  "nyc": {
+    "check-coverage": true,
+    "statements": 100,
+    "branches": 100,
+    "functions": 100,
+    "lines": 100
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,6 @@
   "engines": {
     "node": ">=18"  
   },
-  "nyc": {
-    "check-coverage": true,
-    "statements": 100,
-    "branches": 100,
-    "functions": 100,
-    "lines": 100
-  },
   "files": [
     "LICENSE",
     "README.md",

--- a/test/flowing.js
+++ b/test/flowing.js
@@ -107,7 +107,75 @@ describe('stream flowing', function () {
       }, 500)
     })
   })
+
+  describe('when a web stream exceeds the limit', function () {
+    it('should stop pulling', function (done) {
+      const stream = createInfiniteWebStream()
+
+      getRawBody(stream, {
+        limit: defaultLimit
+      }, function (err) {
+        assert.ok(err)
+        assert.strictEqual(err.type, 'entity.too.large')
+        assert.ok(err.received > defaultLimit)
+        assert.strictEqual(stream.locked, false)
+
+        assertPullsSettle(stream, done)
+      })
+    })
+
+    it('should not pull when length exceeds limit', function (done) {
+      const stream = createInfiniteWebStream()
+
+      getRawBody(stream, {
+        length: defaultLimit * 2,
+        limit: defaultLimit
+      }, function (err) {
+        assert.ok(err)
+        assert.strictEqual(err.type, 'entity.too.large')
+        assert.strictEqual(stream.locked, false)
+
+        // never read: only the stream's own queue priming runs
+        assert.ok(stream.pulls <= 1)
+        assertPullsSettle(stream, done)
+      })
+    })
+  })
 })
+
+/**
+ * The web analogue of asserting a paused stream: after the
+ * queue refills to its high water mark, pulls stop growing.
+ */
+
+function assertPullsSettle (stream, done) {
+  setTimeout(function () {
+    const settled = stream.pulls
+
+    setTimeout(function () {
+      assert.strictEqual(stream.pulls, settled)
+      done()
+    }, 100)
+  }, 100)
+}
+
+function createInfiniteWebStream () {
+  let pulls = 0
+
+  const stream = new ReadableStream({
+    pull (controller) {
+      pulls++
+      controller.enqueue(new Uint8Array(64 * 1024))
+    }
+  })
+
+  // track pull count for tests
+  Object.defineProperty(stream, 'pulls', {
+    get () { return pulls }
+  })
+
+  return stream
+}
 
 function createChunk () {
   const base = Math.random().toString(32)

--- a/test/index.js
+++ b/test/index.js
@@ -236,6 +236,39 @@ describe('Raw Body', function () {
     })
   })
 
+  it('should not invoke the callback synchronously on early errors', function (done) {
+    let returned = false
+
+    getRawBody(createStream(), {
+      length,
+      limit: length - 1
+    }, function (err) {
+      assert.strictEqual(returned, true)
+      assert.strictEqual(err.type, 'entity.too.large')
+      done()
+    })
+
+    returned = true
+  })
+
+  it('should not defer the callback once reading is asynchronous', function (done) {
+    const stream = new EventEmitter()
+    let callbackRan = false
+
+    getRawBody(stream, { length: 0, encoding: true }, function (err, str) {
+      callbackRan = true
+      assert.ifError(err)
+      assert.strictEqual(str, '')
+    })
+
+    stream.emit('end')
+
+    // the stream already ended, so the callback must not
+    // be deferred to a later tick
+    assert.strictEqual(callbackRan, true)
+    done()
+  })
+
   it('should halt the stream on error, even without pause', function (done) {
     const stream = new EventEmitter()
     stream.unpipe = function () {}

--- a/test/index.js
+++ b/test/index.js
@@ -285,6 +285,20 @@ describe('Raw Body', function () {
     done()
   })
 
+  it('should error on streams1 string chunks without an encoding', function (done) {
+    const stream = new EventEmitter()
+    stream.unpipe = function () {}
+
+    getRawBody(stream, function (err) {
+      assert.ok(err)
+      assert.strictEqual(err.code, 'ERR_INVALID_ARG_TYPE')
+      done()
+    })
+
+    stream.emit('data', 'hello')
+    stream.emit('end')
+  })
+
   it('should halt the stream on error, even without pause', function (done) {
     const stream = new EventEmitter()
     stream.unpipe = function () {}
@@ -476,6 +490,38 @@ describe('Raw Body', function () {
         assert.throws(function () {
           getRawBody(createStream(), { encoding: 'utf-8', decoder: 'not a function' })
         }, /option decoder must be a function/)
+      })
+
+      it('should error when the decoder throws while writing', function (done) {
+        getRawBody(createStream(), {
+          encoding: 'utf-8',
+          decoder: function () {
+            return {
+              write () { throw new Error('decoder write failed') },
+              end () { return '' }
+            }
+          }
+        }, function (err) {
+          assert.ok(err)
+          assert.strictEqual(err.message, 'decoder write failed')
+          done()
+        })
+      })
+
+      it('should error when the decoder throws at the end', function (done) {
+        getRawBody(createStream(), {
+          encoding: 'utf-8',
+          decoder: function () {
+            return {
+              write (chunk) { return '' },
+              end () { throw new Error('decoder end failed') }
+            }
+          }
+        }, function (err) {
+          assert.ok(err)
+          assert.strictEqual(err.message, 'decoder end failed')
+          done()
+        })
       })
 
       it('should decode using the custom decoder', function (done) {

--- a/test/index.js
+++ b/test/index.js
@@ -236,6 +236,22 @@ describe('Raw Body', function () {
     })
   })
 
+  it('should prefer the node stream interface when both are present', function (done) {
+    const stream = createStream(Buffer.from('hello, world!'))
+
+    // a wrapper library may decorate a node stream with a
+    // web-stream compatibility shim; the node path must win
+    stream.getReader = function () {
+      throw new Error('getReader should not be called')
+    }
+
+    getRawBody(stream, { encoding: true }, function (err, str) {
+      assert.ifError(err)
+      assert.strictEqual(str, 'hello, world!')
+      done()
+    })
+  })
+
   it('should not invoke the callback synchronously on early errors', function (done) {
     let returned = false
 

--- a/test/index.js
+++ b/test/index.js
@@ -176,10 +176,10 @@ describe('Raw Body', function () {
   })
 
   it('should handle length as string number', function (done) {
-    var testData = 'test'
-    var expectedLength = testData.length
+    const testData = 'test'
+    const expectedLength = testData.length
 
-    var stream = new Readable()
+    const stream = new Readable()
     stream.push(testData)
     stream.push(null)
 
@@ -234,6 +234,33 @@ describe('Raw Body', function () {
       assert.strictEqual(err.type, 'encoding.unsupported')
       done()
     })
+  })
+
+  it('should halt the stream on error, even without pause', function (done) {
+    const stream = new EventEmitter()
+    stream.unpipe = function () {}
+
+    // keep the listeners attached, so late events reach the handlers
+    stream.removeListener = function () { return this }
+
+    let calls = 0
+
+    getRawBody(stream, { limit: 2 }, function (err) {
+      calls++
+      assert.strictEqual(calls, 1)
+      assert.strictEqual(err.status, 413)
+      assert.strictEqual(err.type, 'entity.too.large')
+
+      // late events after completion are ignored
+      stream.emit('data', Buffer.from('more'))
+      stream.emit('aborted')
+      stream.emit('end')
+      stream.emit('error', new Error('boom'))
+
+      done()
+    })
+
+    stream.emit('data', Buffer.from('hello'))
   })
 
   describe('as a promise', function () {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -315,6 +315,26 @@ describe('using web streams', function () {
     assert.strictEqual(stream.locked, false)
   })
 
+  it('should copy chunks whose memory the producer reuses', async function () {
+    // a producer may legally recycle one scratch buffer
+    // across enqueues; retained views would all end up
+    // pointing at the last chunk's bytes
+    const scratch = new Uint8Array(4)
+    const parts = ['aaaa', 'bbbb', 'cccc']
+    let reads = 0
+
+    const stream = new ReadableStream({
+      pull (controller) {
+        if (reads === parts.length) return controller.close()
+        scratch.set(new TextEncoder().encode(parts[reads++]))
+        controller.enqueue(scratch)
+      }
+    })
+
+    const buf = await getRawBody(stream)
+    assert.strictEqual(buf.toString(), 'aaaabbbbcccc')
+  })
+
   it('should release the lock when finished', async function () {
     const stream = createWebStream(['hello, world!'])
     await getRawBody(stream)

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -1,7 +1,13 @@
 const assert = require('assert')
 const getRawBody = require('..')
 const http = require('http')
+const net = require('net')
 const { Readable } = require('stream')
+
+// socket.resetAndDestroy() requires node >= 18.3
+const itLiveReset = typeof net.Socket.prototype.resetAndDestroy === 'function'
+  ? it
+  : it.skip
 
 describe('using web streams', function () {
   it('should read a ReadableStream into a buffer', async function () {
@@ -263,6 +269,51 @@ describe('using web streams', function () {
       req.write('partial')
 
       setTimeout(function () { req.destroy() }, 20)
+    })
+  })
+
+  it('should not map non-abort connection resets to request.aborted', async function () {
+    // a raw socket reset is a transport failure, not a client
+    // abort: the node path passes it through, so must this one.
+    // this is the exact error a net.Socket read produces on a
+    // TCP RST (recreated: producing a live RST needs
+    // socket.resetAndDestroy, which requires node >= 18.3)
+    const reset = new Error('read ECONNRESET')
+    reset.code = 'ECONNRESET'
+
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.error(reset)
+      }
+    })
+
+    await assert.rejects(getRawBody(stream), function (err) {
+      assert.strictEqual(err, reset)
+      assert.notStrictEqual(err.type, 'request.aborted')
+      return true
+    })
+  })
+
+  itLiveReset('should pass through a live socket reset unmapped', function (done) {
+    const server = net.createServer(function (socket) {
+      socket.write('partial')
+      setTimeout(function () { socket.resetAndDestroy() }, 10)
+    })
+
+    server.listen(0, function () {
+      const socket = net.connect(server.address().port)
+
+      socket.on('connect', function () {
+        getRawBody(Readable.toWeb(socket), function (err) {
+          server.close()
+
+          assert.ok(err)
+          assert.strictEqual(err.code, 'ECONNRESET')
+          assert.strictEqual(err.message, 'read ECONNRESET')
+          assert.notStrictEqual(err.type, 'request.aborted')
+          done()
+        })
+      })
     })
   })
 

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -43,6 +43,20 @@ describe('using web streams', function () {
     assert.strictEqual(buf.toString(), 'hello, world!')
   })
 
+  it('should error on string chunks when encoding is set', async function () {
+    // an already-decoded stream, e.g. piped through TextDecoderStream;
+    // re-decoding it with the declared encoding would corrupt the data
+    const stream = createWebStream(['hello, world!'], { binary: false })
+
+    await assert.rejects(getRawBody(stream, { encoding: 'utf-16le' }), function (err) {
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.encoding.set')
+      return true
+    })
+
+    assert.strictEqual(stream.locked, false)
+  })
+
   it('should work with a custom decoder', async function () {
     const iconv = require('iconv-lite')
     const str = await getRawBody(createWebStream([Buffer.from('636f6f6c20f09f9880', 'hex')]), {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -164,6 +164,40 @@ describe('using web streams', function () {
     await assert.rejects(getRawBody(stream), /boom/)
   })
 
+  it('should error when the decoder throws while writing', async function () {
+    const stream = createWebStream(['hello, world!'])
+
+    await assert.rejects(getRawBody(stream, {
+      encoding: 'utf-8',
+      decoder: function () {
+        return {
+          write () { throw new Error('decoder write failed') },
+          end () { return '' }
+        }
+      }
+    }), /decoder write failed/)
+
+    // the lock is released, so the rest of the stream can be handled
+    assert.strictEqual(stream.locked, false)
+    await stream.cancel()
+  })
+
+  it('should error when the decoder throws at the end', async function () {
+    const stream = createWebStream(['hello, world!'])
+
+    await assert.rejects(getRawBody(stream, {
+      encoding: 'utf-8',
+      decoder: function () {
+        return {
+          write (chunk) { return '' },
+          end () { throw new Error('decoder end failed') }
+        }
+      }
+    }), /decoder end failed/)
+
+    assert.strictEqual(stream.locked, false)
+  })
+
   it('should release the lock when finished', async function () {
     const stream = createWebStream(['hello, world!'])
     await getRawBody(stream)
@@ -209,10 +243,26 @@ describe('using web streams', function () {
     assert.strictEqual(str, 'hello, world!')
   })
 
+  it('should not invoke the callback synchronously on early errors', function (done) {
+    let returned = false
+
+    getRawBody(createWebStream(['hello, world!']), {
+      length: 13,
+      limit: 5
+    }, function (err) {
+      assert.strictEqual(returned, true)
+      assert.strictEqual(err.type, 'entity.too.large')
+      done()
+    })
+
+    returned = true
+  })
+
   it('should ignore reads that settle after completion', function (done) {
     let released = false
 
-    // stream whose reader settles the same read multiple times
+    // stream whose reader settles the same read multiple times;
+    // promise assimilation must neutralize the extra settlements
     const stream = {
       locked: false,
       getReader () {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -129,6 +129,30 @@ describe('using web streams', function () {
     reader.releaseLock()
   })
 
+  it('should error when the body was already consumed', async function () {
+    const res = new Response('hello, world!')
+    await res.text()
+
+    await assert.rejects(getRawBody(res.body), function (err) {
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.not.readable')
+      return true
+    })
+  })
+
+  it('should error when the stream is locked by a pipe', async function () {
+    const stream = createWebStream(['hello, world!'])
+    const piped = stream.pipeThrough(new TextDecoderStream())
+
+    await assert.rejects(getRawBody(stream), function (err) {
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.not.readable')
+      return true
+    })
+
+    await piped.cancel()
+  })
+
   it('should propagate stream errors', async function () {
     const stream = new ReadableStream({
       start (controller) {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -1,5 +1,7 @@
 const assert = require('assert')
 const getRawBody = require('..')
+const http = require('http')
+const { Readable } = require('stream')
 
 describe('using web streams', function () {
   it('should read a ReadableStream into a buffer', async function () {
@@ -230,6 +232,54 @@ describe('using web streams', function () {
       assert.strictEqual(err.received, 3)
       return true
     })
+  })
+
+  it('should map aborts from Readable.toWeb request streams', function (done) {
+    const server = http.createServer(function (req, res) {
+      getRawBody(Readable.toWeb(req), {
+        length: req.headers['content-length'],
+        limit: '1kb'
+      }, function (err) {
+        res.destroy()
+        server.close()
+
+        assert.ok(err)
+        assert.strictEqual(err.status, 400)
+        assert.strictEqual(err.type, 'request.aborted')
+        assert.strictEqual(err.code, 'ECONNABORTED')
+        assert.ok(err.cause)
+        done()
+      })
+    })
+
+    server.listen(0, function () {
+      const req = http.request({
+        port: server.address().port,
+        method: 'POST',
+        headers: { 'content-length': '100' }
+      })
+
+      req.on('error', function () {}) // socket hang up
+      req.write('partial')
+
+      setTimeout(function () { req.destroy() }, 20)
+    })
+  })
+
+  it('should map destroyed Readable.toWeb streams to request.aborted', function (done) {
+    const nodeStream = new Readable({ read () {} })
+    const webStream = Readable.toWeb(nodeStream)
+
+    getRawBody(webStream, function (err) {
+      assert.ok(err)
+      assert.strictEqual(err.status, 400)
+      assert.strictEqual(err.type, 'request.aborted')
+      assert.strictEqual(err.received, 7)
+      done()
+    })
+
+    nodeStream.push(Buffer.from('partial'))
+    setTimeout(function () { nodeStream.destroy() }, 10)
   })
 
   it('should propagate stream errors', async function () {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -513,32 +513,41 @@ describe('using web streams', function () {
     returned = true
   })
 
-  it('should not catch or re-invoke a callback that throws', function (done) {
+  it('should not catch or re-invoke a callback that throws', async function () {
     // take over unhandled rejections for this test, so mocha's
     // own handler does not fail the test for the expected one
     const listeners = process.listeners('unhandledRejection')
     process.removeAllListeners('unhandledRejection')
 
     let calls = 0
+    let timer
     const failure = new Error('callback bug')
 
-    process.once('unhandledRejection', function (err) {
-      for (const listener of listeners) {
-        process.on('unhandledRejection', listener)
-      }
+    try {
+      const caught = new Promise(function (resolve, reject) {
+        process.once('unhandledRejection', resolve)
+        timer = setTimeout(reject, 1000, new Error('expected an unhandled rejection'))
+      })
+
+      getRawBody(createWebStream(['hello, world!']), function () {
+        calls++
+        throw failure
+      })
 
       // the throw must surface as an unhandled rejection with
       // the original error — not be misread as a stream error
       // and invoke the callback again
-      assert.strictEqual(err, failure)
+      assert.strictEqual(await caught, failure)
       assert.strictEqual(calls, 1)
-      done()
-    })
+    } finally {
+      // restore mocha's handlers no matter how the test ends
+      clearTimeout(timer)
+      process.removeAllListeners('unhandledRejection')
 
-    getRawBody(createWebStream(['hello, world!']), function () {
-      calls++
-      throw failure
-    })
+      for (const listener of listeners) {
+        process.on('unhandledRejection', listener)
+      }
+    }
   })
 
   it('should release the lock on error', async function () {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -66,6 +66,23 @@ describe('using web streams', function () {
     assert.strictEqual(str, 'cool 😀')
   })
 
+  it('should decode encodings unsupported by TextDecoder', async function () {
+    const iconv = require('iconv-lite')
+    const bytes = iconv.encode('¿Cómo estás?', 'utf-32le')
+
+    // split mid-character: each utf-32 code unit is 4 bytes,
+    // so the decoder must carry state across chunks
+    const str = await getRawBody(createWebStream([
+      bytes.subarray(0, 6),
+      bytes.subarray(6)
+    ]), {
+      encoding: 'utf-32le',
+      decoder: iconv.getDecoder.bind(iconv)
+    })
+
+    assert.strictEqual(str, '¿Cómo estás?')
+  })
+
   it('should work with the callback style', function (done) {
     getRawBody(createWebStream(['hello, world!']), function (err, buf) {
       assert.ifError(err)

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -1,0 +1,249 @@
+const assert = require('assert')
+const getRawBody = require('..')
+
+describe('using web streams', function () {
+  it('should read a ReadableStream into a buffer', async function () {
+    const buf = await getRawBody(createWebStream(['hello', ', ', 'world!']))
+    assert.ok(Buffer.isBuffer(buf))
+    assert.strictEqual(buf.toString(), 'hello, world!')
+  })
+
+  it('should read an empty ReadableStream', async function () {
+    const buf = await getRawBody(createWebStream([]))
+    assert.ok(Buffer.isBuffer(buf))
+    assert.strictEqual(buf.length, 0)
+  })
+
+  it('should work with encoding', async function () {
+    const str = await getRawBody(createWebStream(['hello, world!']), {
+      encoding: 'utf-8'
+    })
+    assert.strictEqual(str, 'hello, world!')
+  })
+
+  it('should work with `true` as an option', async function () {
+    const str = await getRawBody(createWebStream(['hello, world!']), true)
+    assert.strictEqual(str, 'hello, world!')
+  })
+
+  it('should decode multi-byte characters split across chunks', async function () {
+    const bytes = Buffer.from('é€好', 'utf-8')
+    const str = await getRawBody(createWebStream([
+      bytes.subarray(0, 3),
+      bytes.subarray(3)
+    ]), {
+      encoding: 'utf-8'
+    })
+    assert.strictEqual(str, 'é€好')
+  })
+
+  it('should work with string chunks', async function () {
+    const buf = await getRawBody(createWebStream(['hello', ', world!'], { binary: false }))
+    assert.ok(Buffer.isBuffer(buf))
+    assert.strictEqual(buf.toString(), 'hello, world!')
+  })
+
+  it('should work with a custom decoder', async function () {
+    const iconv = require('iconv-lite')
+    const str = await getRawBody(createWebStream([Buffer.from('636f6f6c20f09f9880', 'hex')]), {
+      encoding: 'utf-8',
+      decoder: iconv.getDecoder.bind(iconv)
+    })
+    assert.strictEqual(str, 'cool 😀')
+  })
+
+  it('should work with the callback style', function (done) {
+    getRawBody(createWebStream(['hello, world!']), function (err, buf) {
+      assert.ifError(err)
+      assert.strictEqual(buf.toString(), 'hello, world!')
+      done()
+    })
+  })
+
+  it('should check length', async function () {
+    const buf = await getRawBody(createWebStream(['hello, world!']), {
+      length: 13
+    })
+    assert.strictEqual(buf.toString(), 'hello, world!')
+  })
+
+  it('should error with length mismatch', async function () {
+    await assert.rejects(getRawBody(createWebStream(['hello, world!']), {
+      length: 10
+    }), function (err) {
+      assert.strictEqual(err.status, 400)
+      assert.strictEqual(err.type, 'request.size.invalid')
+      assert.strictEqual(err.expected, 10)
+      assert.strictEqual(err.received, 13)
+      return true
+    })
+  })
+
+  it('should error when limit is exceeded', async function () {
+    await assert.rejects(getRawBody(createWebStream(['hello, world!']), {
+      limit: 5
+    }), function (err) {
+      assert.strictEqual(err.status, 413)
+      assert.strictEqual(err.type, 'entity.too.large')
+      assert.strictEqual(err.limit, 5)
+      return true
+    })
+  })
+
+  it('should error early when length > limit', async function () {
+    const stream = createWebStream(['hello, world!'])
+
+    await assert.rejects(getRawBody(stream, {
+      length: 13,
+      limit: 5
+    }), function (err) {
+      assert.strictEqual(err.status, 413)
+      assert.strictEqual(err.type, 'entity.too.large')
+      return true
+    })
+
+    // the stream was never locked, so it is still usable
+    assert.strictEqual(stream.locked, false)
+  })
+
+  it('should error for an unsupported encoding', async function () {
+    await assert.rejects(getRawBody(createWebStream(['hello, world!']), {
+      encoding: 'foo/bar'
+    }), function (err) {
+      assert.strictEqual(err.status, 415)
+      assert.strictEqual(err.type, 'encoding.unsupported')
+      return true
+    })
+  })
+
+  it('should error when the stream is locked', async function () {
+    const stream = createWebStream(['hello, world!'])
+    const reader = stream.getReader()
+
+    await assert.rejects(getRawBody(stream), function (err) {
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.not.readable')
+      return true
+    })
+
+    reader.releaseLock()
+  })
+
+  it('should propagate stream errors', async function () {
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.enqueue(new TextEncoder().encode('hello'))
+        controller.error(new Error('boom'))
+      }
+    })
+
+    await assert.rejects(getRawBody(stream), /boom/)
+  })
+
+  it('should release the lock when finished', async function () {
+    const stream = createWebStream(['hello, world!'])
+    await getRawBody(stream)
+    assert.strictEqual(stream.locked, false)
+  })
+
+  it('should read the body of a fetch Response', async function () {
+    const res = new Response('hello, world!')
+    const str = await getRawBody(res.body, {
+      encoding: 'utf-8',
+      limit: '1kb'
+    })
+    assert.strictEqual(str, 'hello, world!')
+  })
+
+  it('should read the stream of a Blob', async function () {
+    const blob = new Blob(['hello, world!'])
+    const str = await getRawBody(blob.stream(), {
+      encoding: 'utf-8'
+    })
+    assert.strictEqual(str, 'hello, world!')
+  })
+
+  it('should read the body of a fetch Request', async function () {
+    const req = new Request('http://localhost/', {
+      method: 'POST',
+      body: 'hello, world!'
+    })
+    const str = await getRawBody(req.body, {
+      encoding: 'utf-8'
+    })
+    assert.strictEqual(str, 'hello, world!')
+  })
+
+  it('should read the readable side of a TransformStream', async function () {
+    const gzipped = await getRawBody(
+      new Blob(['hello, world!']).stream().pipeThrough(new CompressionStream('gzip'))
+    )
+    const str = await getRawBody(
+      new Blob([gzipped]).stream().pipeThrough(new DecompressionStream('gzip')),
+      { encoding: 'utf-8' }
+    )
+    assert.strictEqual(str, 'hello, world!')
+  })
+
+  it('should ignore reads that settle after completion', function (done) {
+    let released = false
+
+    // stream whose reader settles the same read multiple times
+    const stream = {
+      locked: false,
+      getReader () {
+        return {
+          releaseLock () { released = true },
+          read () {
+            return {
+              then (resolve, reject) {
+                // exceeds the limit, so this completes the read
+                resolve({ done: false, value: Buffer.from('hello, world!') })
+
+                // misbehaving thenable: settles again after completion
+                resolve({ done: false, value: Buffer.from('more') })
+                reject(new Error('boom'))
+              }
+            }
+          }
+        }
+      }
+    }
+
+    let calls = 0
+
+    getRawBody(stream, { limit: 5 }, function (err) {
+      calls++
+      assert.strictEqual(calls, 1)
+      assert.strictEqual(err.status, 413)
+      assert.strictEqual(err.type, 'entity.too.large')
+      assert.strictEqual(released, true)
+      done()
+    })
+  })
+
+  it('should release the lock on error', async function () {
+    const stream = createWebStream(['hello', ', world!'])
+
+    await assert.rejects(getRawBody(stream, { limit: 3 }))
+
+    // the lock is released, so the rest of the stream can be handled
+    assert.strictEqual(stream.locked, false)
+    await stream.cancel()
+  })
+})
+
+function createWebStream (chunks, options) {
+  const binary = !options || options.binary !== false
+
+  return new ReadableStream({
+    start (controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(binary && typeof chunk === 'string'
+          ? new TextEncoder().encode(chunk)
+          : chunk)
+      }
+      controller.close()
+    }
+  })
+}

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -198,6 +198,30 @@ describe('using web streams', function () {
     assert.strictEqual(stream.locked, false)
   })
 
+  it('should reject when the stream errors without a reason', async function () {
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.error()
+      }
+    })
+
+    await assert.rejects(getRawBody(stream), /stream error/)
+  })
+
+  it('should error when the stream yields an invalid chunk', async function () {
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.enqueue(undefined)
+        controller.close()
+      }
+    })
+
+    await assert.rejects(getRawBody(stream), TypeError)
+
+    // the lock is released, so the rest of the stream can be handled
+    assert.strictEqual(stream.locked, false)
+  })
+
   it('should release the lock when finished', async function () {
     const stream = createWebStream(['hello, world!'])
     await getRawBody(stream)

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -153,6 +153,54 @@ describe('using web streams', function () {
     await piped.cancel()
   })
 
+  it('should error when the stream was cancelled', async function () {
+    const stream = createWebStream(['hello, world!'])
+    await stream.cancel()
+
+    await assert.rejects(getRawBody(stream), function (err) {
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.not.readable')
+      return true
+    })
+  })
+
+  it('should error when the stream was already read', async function () {
+    const stream = createWebStream(['hello, world!'])
+    const reader = stream.getReader()
+    while (!(await reader.read()).done);
+    reader.releaseLock()
+
+    await assert.rejects(getRawBody(stream), function (err) {
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.not.readable')
+      return true
+    })
+  })
+
+  it('should map aborts to request.aborted', async function () {
+    // deliver one chunk, then abort: erroring in start() would
+    // discard the queued chunk, so error on the second pull
+    let pulls = 0
+    const stream = new ReadableStream({
+      pull (controller) {
+        if (pulls++ === 0) {
+          controller.enqueue(new TextEncoder().encode('hel'))
+        } else {
+          controller.error(new DOMException('This operation was aborted', 'AbortError'))
+        }
+      }
+    })
+
+    await assert.rejects(getRawBody(stream, { length: 10 }), function (err) {
+      assert.strictEqual(err.status, 400)
+      assert.strictEqual(err.type, 'request.aborted')
+      assert.strictEqual(err.code, 'ECONNABORTED')
+      assert.strictEqual(err.expected, 10)
+      assert.strictEqual(err.received, 3)
+      return true
+    })
+  })
+
   it('should propagate stream errors', async function () {
     const stream = new ReadableStream({
       start (controller) {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -222,6 +222,20 @@ describe('using web streams', function () {
     assert.strictEqual(stream.locked, false)
   })
 
+  it('should error when the stream yields non-byte chunks', async function () {
+    // an ArrayBuffer has no .length, which previously poisoned
+    // the limit accounting with NaN, disabling the limit
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.enqueue(new ArrayBuffer(10))
+        controller.close()
+      }
+    })
+
+    await assert.rejects(getRawBody(stream, { limit: 5 }), /Uint8Array or string/)
+    assert.strictEqual(stream.locked, false)
+  })
+
   it('should release the lock when finished', async function () {
     const stream = createWebStream(['hello, world!'])
     await getRawBody(stream)

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -327,6 +327,23 @@ describe('using web streams', function () {
     assert.strictEqual(stream.locked, false)
   })
 
+  it('should normalize non-Error stream failures', async function () {
+    // e.g. controller.error('timeout') or abort(reason) with a
+    // string: callers must always receive an Error instance
+    const stream = new ReadableStream({
+      start (controller) {
+        controller.error('timeout')
+      }
+    })
+
+    await assert.rejects(getRawBody(stream), function (err) {
+      assert.ok(err instanceof Error)
+      assert.strictEqual(err.message, 'stream error')
+      assert.strictEqual(err.cause, 'timeout')
+      return true
+    })
+  })
+
   it('should reject when the stream errors without a reason', async function () {
     const stream = new ReadableStream({
       start (controller) {

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -462,41 +462,31 @@ describe('using web streams', function () {
     returned = true
   })
 
-  it('should ignore reads that settle after completion', function (done) {
-    let released = false
-
-    // stream whose reader settles the same read multiple times;
-    // promise assimilation must neutralize the extra settlements
-    const stream = {
-      locked: false,
-      getReader () {
-        return {
-          releaseLock () { released = true },
-          read () {
-            return {
-              then (resolve, reject) {
-                // exceeds the limit, so this completes the read
-                resolve({ done: false, value: Buffer.from('hello, world!') })
-
-                // misbehaving thenable: settles again after completion
-                resolve({ done: false, value: Buffer.from('more') })
-                reject(new Error('boom'))
-              }
-            }
-          }
-        }
-      }
-    }
+  it('should not catch or re-invoke a callback that throws', function (done) {
+    // take over unhandled rejections for this test, so mocha's
+    // own handler does not fail the test for the expected one
+    const listeners = process.listeners('unhandledRejection')
+    process.removeAllListeners('unhandledRejection')
 
     let calls = 0
+    const failure = new Error('callback bug')
 
-    getRawBody(stream, { limit: 5 }, function (err) {
-      calls++
+    process.once('unhandledRejection', function (err) {
+      for (const listener of listeners) {
+        process.on('unhandledRejection', listener)
+      }
+
+      // the throw must surface as an unhandled rejection with
+      // the original error — not be misread as a stream error
+      // and invoke the callback again
+      assert.strictEqual(err, failure)
       assert.strictEqual(calls, 1)
-      assert.strictEqual(err.status, 413)
-      assert.strictEqual(err.type, 'entity.too.large')
-      assert.strictEqual(released, true)
       done()
+    })
+
+    getRawBody(createWebStream(['hello, world!']), function () {
+      calls++
+      throw failure
     })
   })
 


### PR DESCRIPTION
getRawBody() now accepts web streams in addition to Node.js readable streams: fetch Request/Response bodies, Blob.stream(), TransformStream readables, and Readable.toWeb() bridges. Both the promise and callback styles work, with the same length, limit, encoding, and decoder options.

```js
const buf = await getRawBody(request.body, { limit: '1mb' })
const str = await getRawBody(blob.stream(), { encoding: 'utf-8' })
```
Dispatch is duck-typed: objects with .on use the historical node path (precedence 
preserved for objects exposing both interfaces); objects with .getReader use the new web path.


Web streams produce the same error contract as node streams (`status`, `type`, and the properties consumers already branch on):

| Condition | Result |
|---|---|
| body larger than `limit` (checked per chunk) | 413 `entity.too.large` |
| `length` > `limit` (early check, stream never read) | 413 `entity.too.large` |
| received bytes ≠ `length` | 400 `request.size.invalid` |
| unsupported `encoding` | 415 `encoding.unsupported` |
| stream locked to another reader, already read, or cancelled | 500 `stream.not.readable` |
| client abort (undici `AbortError`, `Readable.toWeb` destroy, node http `ECONNRESET 'aborted'`) | 400 `request.aborted`, `ECONNABORTED`, original error in `cause` |
| other connection resets (e.g. raw socket RST) | passed through, as on the node path |
| stream errored with a non-Error reason (`controller.error('x')`, no reason) | normalized to an `Error` with the reason in `cause` |
| string chunks, no encoding | UTF-8 `Buffer` (matches legacy streams1 handling) |
| string chunks with an encoding | 500 `stream.encoding.set` — the stream is already decoded; re-decoding would corrupt data |
| non-byte chunks (`ArrayBuffer`, objects) | `TypeError`, at the offending chunk |

