### PR TITLE
chore: update minimum Node.js version to 22.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [22.0.0, 22, 23, 24, 25, 26]
         # Node.js release schedule: https://nodejs.org/en/about/releases/
+        exclude:
+          # npm bundled with Node.js 22.0.0 is broken on Windows
+          - os: windows-latest
+            node-version: 22.0.0
     name: Node.js ${{ matrix.node-version }} - ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18.12.0, 18, 19, 20, 21, 22, 23, 24, 25]
+        node-version: [20.0.0, 20, 21, 22, 23, 24, 25, 26]
         # Node.js release schedule: https://nodejs.org/en/about/releases/
     name: Node.js ${{ matrix.node-version }} - ${{matrix.os}}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18.0.0, 18, 19, 20, 21, 22, 23, 24, 25]
+        node-version: [18.12.0, 18, 19, 20, 21, 22, 23, 24, 25]
         # Node.js release schedule: https://nodejs.org/en/about/releases/
     name: Node.js ${{ matrix.node-version }} - ${{matrix.os}}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.0.0, 20, 21, 22, 23, 24, 25, 26]
+        node-version: [22.0.0, 22, 23, 24, 25, 26]
         # Node.js release schedule: https://nodejs.org/en/about/releases/
     name: Node.js ${{ matrix.node-version }} - ${{matrix.os}}
     runs-on: ${{ matrix.os }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,7 +28,7 @@ unreleased
   * Add `decoder` option to plug in a custom decoder (e.g. `iconv-lite`'s
     `getDecoder`) for encodings outside the WHATWG Encoding Standard
   * Remove the check for a global `Promise` when no callback is provided
-  * Breaking Change: Node.js 18.12 is the minimum supported version
+  * Breaking Change: Node.js 20 is the minimum supported version
 
 3.0.2 / 2025-11-21
 ======================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,7 +28,7 @@ unreleased
   * Add `decoder` option to plug in a custom decoder (e.g. `iconv-lite`'s
     `getDecoder`) for encodings outside the WHATWG Encoding Standard
   * Remove the check for a global `Promise` when no callback is provided
-  * Breaking Change: Node.js 18 is the minimum supported version
+  * Breaking Change: Node.js 18.12 is the minimum supported version
 
 3.0.2 / 2025-11-21
 ======================

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nyc": "17.0.0"
   },
   "engines": {
-    "node": ">=18"  
+    "node": ">=18.12"  
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nyc": "17.0.0"
   },
   "engines": {
-    "node": ">=18.12"  
+    "node": ">=20"  
   },
   "files": [
     "LICENSE",

--- a/test/webstream.js
+++ b/test/webstream.js
@@ -4,11 +4,6 @@ const http = require('http')
 const net = require('net')
 const { Readable } = require('stream')
 
-// socket.resetAndDestroy() requires node >= 18.3
-const itLiveReset = typeof net.Socket.prototype.resetAndDestroy === 'function'
-  ? it
-  : it.skip
-
 describe('using web streams', function () {
   it('should read a ReadableStream into a buffer', async function () {
     const buf = await getRawBody(createWebStream(['hello', ', ', 'world!']))
@@ -272,29 +267,7 @@ describe('using web streams', function () {
     })
   })
 
-  it('should not map non-abort connection resets to request.aborted', async function () {
-    // a raw socket reset is a transport failure, not a client
-    // abort: the node path passes it through, so must this one.
-    // this is the exact error a net.Socket read produces on a
-    // TCP RST (recreated: producing a live RST needs
-    // socket.resetAndDestroy, which requires node >= 18.3)
-    const reset = new Error('read ECONNRESET')
-    reset.code = 'ECONNRESET'
-
-    const stream = new ReadableStream({
-      start (controller) {
-        controller.error(reset)
-      }
-    })
-
-    await assert.rejects(getRawBody(stream), function (err) {
-      assert.strictEqual(err, reset)
-      assert.notStrictEqual(err.type, 'request.aborted')
-      return true
-    })
-  })
-
-  itLiveReset('should pass through a live socket reset unmapped', function (done) {
+  it('should pass through a live socket reset unmapped', function (done) {
     const server = net.createServer(function (socket) {
       socket.write('partial')
       setTimeout(function () { socket.resetAndDestroy() }, 10)


### PR DESCRIPTION
Since we support Web Streams, I'd target the LTS branch as well. Also, whether we include #33 in a minor release or not, it fixes bugs.