### PR TITLE
fix: improve error handling for non-readable streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ chunks are accepted and encoded as UTF-8 into the returned `Buffer`.)
 #### stream.not.readable
 
 This error will occur when the given stream is not readable, or, for a web
-stream, when it is already locked to another reader, already read, or
-cancelled.
+stream, when it is locked to another reader. A web stream that was already
+read or cancelled cannot be detected portably across runtimes and reads as
+an empty body.
 
 ## Examples
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,6 @@ import type { ReadableStreamReadResult } from 'node:stream/web'
 import bytes from 'bytes'
 import createError from 'http-errors'
 
-const { isDisturbed } = Readable
-
 /**
  * The encoding to decode the body with. `true` decodes as `utf-8`.
  */
@@ -510,9 +508,10 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
     return fail(entityTooLargeError({ expected: length, length, limit }))
   }
 
-  // reject streams locked to another reader, and streams
-  // already read or cancelled (disturbed)
-  if (stream.locked || isDisturbed(stream)) {
+  // reject streams locked to another reader. note: cancelled or
+  // fully-read streams cannot be detected portably (no runtime-agnostic
+  // access to the disturbed flag) and read as an empty body
+  if (stream.locked) {
     return fail(notReadableError())
   }
 

--- a/test/support/runtime.ts
+++ b/test/support/runtime.ts
@@ -4,11 +4,3 @@
  */
 
 export const isBun = typeof process.versions.bun === 'string'
-
-export const isDeno = typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined'
-
-/**
- * `Readable.isDisturbed` only recognizes web streams created by Node.js
- * itself, so cancelled/consumed streams cannot be detected on Bun or Deno.
- */
-export const hasIsDisturbed = !isBun && !isDeno

--- a/test/webstream.spec.ts
+++ b/test/webstream.spec.ts
@@ -6,7 +6,7 @@ import type { ReadableWritablePair } from 'node:stream/web'
 import iconv from 'iconv-lite'
 import { describe, it } from 'vitest'
 import getRawBody, { type RawBodyError } from '../src/index.ts'
-import { hasIsDisturbed, isBun } from './support/runtime.ts'
+import { isBun } from './support/runtime.ts'
 import { withDone } from './support/with-done.ts'
 
 describe('using web streams', function () {
@@ -190,28 +190,26 @@ describe('using web streams', function () {
     await piped.cancel()
   })
 
-  it.skipIf(!hasIsDisturbed)('should error when the stream was cancelled', async function () {
+  // a disturbed stream cannot be told apart from an empty one portably,
+  // so cancelled and fully-read streams read as an empty body
+  it('should read a cancelled stream as an empty body', async function () {
     const stream = createWebStream(['hello, world!'])
     await stream.cancel()
 
-    await assert.rejects(getRawBody(stream), function (err: RawBodyError) {
-      assert.strictEqual(err.status, 500)
-      assert.strictEqual(err.type, 'stream.not.readable')
-      return true
-    })
+    const buf = await getRawBody(stream)
+    assert.ok(Buffer.isBuffer(buf))
+    assert.strictEqual(buf.length, 0)
   })
 
-  it.skipIf(!hasIsDisturbed)('should error when the stream was already read', async function () {
+  it('should read an already-read stream as an empty body', async function () {
     const stream = createWebStream(['hello, world!'])
     const reader = stream.getReader()
     while (!(await reader.read()).done);
     reader.releaseLock()
 
-    await assert.rejects(getRawBody(stream), function (err: RawBodyError) {
-      assert.strictEqual(err.status, 500)
-      assert.strictEqual(err.type, 'stream.not.readable')
-      return true
-    })
+    const buf = await getRawBody(stream)
+    assert.ok(Buffer.isBuffer(buf))
+    assert.strictEqual(buf.length, 0)
   })
 
   it('should map aborts to request.aborted', async function () {
@@ -463,6 +461,39 @@ describe('using web streams', function () {
       encoding: 'utf-8'
     })
     assert.strictEqual(str, 'hello, world!')
+  })
+
+  it('should map an aborted fetch Response body to request.aborted', async function () {
+    // a fetch response cut off by an AbortController mid-body: the fetch
+    // spec errors the body stream with the abort reason (an AbortError)
+    const server = http.createServer(function (req, res) {
+      res.writeHead(200, { 'content-length': '100' })
+      res.write('partial')
+      // never end: the client aborts first
+    })
+
+    await new Promise<void>(function (resolve) { server.listen(0, function () { resolve() }) })
+
+    try {
+      const controller = new AbortController()
+      const res = await fetch('http://localhost:' + (server.address() as net.AddressInfo).port, {
+        signal: controller.signal
+      })
+
+      setTimeout(function () { controller.abort() }, 20)
+
+      await assert.rejects(getRawBody(res.body!, { length: 100 }), function (err: RawBodyError) {
+        assert.strictEqual(err.status, 400)
+        assert.strictEqual(err.type, 'request.aborted')
+        assert.strictEqual(err.code, 'ECONNABORTED')
+        assert.strictEqual(err.expected, 100)
+        assert.strictEqual(err.received, 7)
+        assert.ok(err.cause)
+        return true
+      })
+    } finally {
+      server.close()
+    }
   })
 
   it('should read the readable side of a TransformStream', async function () {


### PR DESCRIPTION
Basically, `isDisturbed` is a Node.js-specific concept. The Web Streams API doesn't provide a way to tell whether a stream has been canceled or otherwise disturbed like `isDisturbed` does. Hono and Elysia may have the same issue, but that's currently a limitation of the platform rather than something they can solve.

[https://github.com/whatwg/streams/issues/1025](https://github.com/whatwg/streams/issues/1025)
