### PR TITLE
chore: remove support for stream1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -442,21 +442,24 @@ function readStream (stream: NodeJS.ReadableStream & { readableEncoding?: string
   function onData (chunk: Buffer | string): void {
     if (complete) return
 
+    // string chunks mean the stream is already decoded: the
+    // readableEncoding assertion covers real streams
+    if (typeof chunk === 'string') {
+      return done(encodingSetError())
+    }
+
     received += chunk.length
 
     if (limit !== null && received > limit) {
       done(entityTooLargeError({ limit, received }))
     } else if (decoder) {
-      // streams1 may emit string chunks
-      const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
-
       try {
-        buffer += decoder.write(buf)
+        buffer += decoder.write(chunk)
       } catch (err) {
         done(err as Error)
       }
     } else {
-      (buffer as Buffer[]).push(chunk as Buffer)
+      (buffer as Buffer[]).push(chunk)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,9 +348,7 @@ function halt (stream: NodeJS.ReadableStream): void {
   stream.unpipe()
 
   // pause stream
-  if (typeof stream.pause === 'function') {
-    stream.pause()
-  }
+  stream.pause()
 }
 
 /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -348,13 +348,14 @@ describe('Raw Body', function () {
     done()
   }))
 
-  it('should error on streams1 string chunks without an encoding', withDone(function (done) {
+  it('should error on string chunks without an encoding', withDone(function (done) {
     const stream = new EventEmitter() as EventEmitter & { unpipe: () => void }
     stream.unpipe = function () {}
 
     getRawBody(stream as never, function (err) {
       assert.ok(err)
-      assert.strictEqual(err.code, 'ERR_INVALID_ARG_TYPE')
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.encoding.set')
       done()
     })
 
@@ -647,15 +648,19 @@ describe('Raw Body', function () {
     }))
   })
 
-  it('should work on streams1 stream', withDone(function (done) {
-    const stream = new EventEmitter()
+  it('should error on string chunks even with an encoding', withDone(function (done) {
+    // string chunks are already decoded, like the web path: decoding
+    // them again with the declared encoding would corrupt the data
+    const stream = new EventEmitter() as EventEmitter & { unpipe: () => void }
+    stream.unpipe = function () {}
 
     getRawBody(stream as never, {
       encoding: true,
       length: 19
-    }, function (err: Error | null | undefined, value: string) {
-      assert.ifError(err)
-      assert.strictEqual(value, 'foobar,foobaz,yay!!')
+    }, function (err) {
+      assert.ok(err)
+      assert.strictEqual(err.status, 500)
+      assert.strictEqual(err.type, 'stream.encoding.set')
       done()
     })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -349,8 +349,9 @@ describe('Raw Body', function () {
   }))
 
   it('should error on string chunks without an encoding', withDone(function (done) {
-    const stream = new EventEmitter() as EventEmitter & { unpipe: () => void }
+    const stream = new EventEmitter() as EventEmitter & { unpipe: () => void, pause: () => void }
     stream.unpipe = function () {}
+    stream.pause = function () {}
 
     getRawBody(stream as never, function (err) {
       assert.ok(err)
@@ -363,9 +364,10 @@ describe('Raw Body', function () {
     stream.emit('end')
   }))
 
-  it('should halt the stream on error, even without pause', withDone(function (done) {
-    const stream = new EventEmitter() as EventEmitter & { unpipe: () => void }
+  it('should halt the stream on error', withDone(function (done) {
+    const stream = new EventEmitter() as EventEmitter & { unpipe: () => void, pause: () => void }
     stream.unpipe = function () {}
+    stream.pause = function () {}
 
     // keep the listeners attached, so late events reach the handlers
     stream.removeListener = function () { return this }
@@ -651,8 +653,9 @@ describe('Raw Body', function () {
   it('should error on string chunks even with an encoding', withDone(function (done) {
     // string chunks are already decoded, like the web path: decoding
     // them again with the declared encoding would corrupt the data
-    const stream = new EventEmitter() as EventEmitter & { unpipe: () => void }
+    const stream = new EventEmitter() as EventEmitter & { unpipe: () => void, pause: () => void }
     stream.unpipe = function () {}
+    stream.pause = function () {}
 
     getRawBody(stream as never, {
       encoding: true,


### PR DESCRIPTION
Basically, we don't need to support this anymore. All Node.js APIs use Streams2/3, so there's no need to keep this compatibility around, especially since we already require Node.js >=22.
