### PR TITLE
fix: validate limit option and throw error for invalid values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -311,6 +311,12 @@ function getRawBody (stream: RawBodyStream, options?: Readonly<Options> | Encodi
   // convert the limit to an integer
   const limit = opts.limit == null ? null : bytes.parse(opts.limit)
 
+  // an unparseable limit is a developer error: silently reading
+  // with no limit at all would disable the protection
+  if (opts.limit != null && limit === null) {
+    throw new TypeError('option limit must be a number of bytes or a byte size string')
+  }
+
   // convert the expected length to an integer
   const length = opts.length != null && !Number.isNaN(Number(opts.length))
     ? parseInt(String(opts.length), 10)

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -97,6 +97,18 @@ describe('Raw Body', function () {
     })
   }))
 
+  it('should throw on a limit that does not parse', function () {
+    assert.throws(function () {
+      getRawBody(createStream(), { limit: 'banana' }, function () {})
+    }, /option limit must be a number of bytes or a byte size string/)
+  })
+
+  it('should throw on a NaN limit', function () {
+    assert.throws(function () {
+      getRawBody(createStream(), { limit: NaN }, function () {})
+    }, /option limit must be a number of bytes or a byte size string/)
+  })
+
   it('should work with limit and length', withDone(function (done) {
     getRawBody(createStream(), {
       length,


### PR DESCRIPTION
As a safeguard in case someone accidentally introduces a typo in that option.