### PR TITLE
fix: adjust size limit for raw body in web streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "4.5 KB",
+      "limit": "4.75 KB",
       "ignore": [
         "node:async_hooks",
         "node:stream"

--- a/src/index.ts
+++ b/src/index.ts
@@ -517,6 +517,8 @@ function toBuffer (chunk: unknown): Buffer {
 
 function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: string | undefined | null, length: number | null, limit: number | null, createDecoder: CreateDecoder | undefined, callback: InternalCallback): void {
   let buffer: string | Buffer[] | null
+  let body: Uint8Array | null = null
+  let offset = 0
   let reader: ReadableStreamDefaultReader<Uint8Array | string> | null = null
 
   // check the length and limit options.
@@ -580,6 +582,7 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
 
   function done (err?: Error | null, string?: Buffer | string): void {
     buffer = null
+    body = null
 
     if (reader) {
       // release the stream, so users can handle the rest themselves
@@ -589,9 +592,30 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
     callback(err, string)
   }
 
+  /**
+   * Copy the chunk (the producer may reuse its memory) straight
+   * into the preallocated body, skipping the assembly copy.
+   */
+
+  function append (chunk: Buffer): void {
+    if (body === null) {
+      // only trust the declared length when the limit bounds it
+      const size = limit !== null ? length! : Math.min(length!, 1024 * 1024)
+
+      body = new Uint8Array(Math.max(size, received))
+    } else if (received > body.length) {
+      // excess over a capped allocation still has to be buffered
+      const grown = new Uint8Array(Math.max(body.length * 2, received))
+      grown.set(body.subarray(0, offset))
+      body = grown
+    }
+
+    body.set(chunk, offset)
+    offset = received
+  }
+
   function onRead (result: ReadableStreamReadResult<Uint8Array | string>): void {
-    // received is an exact byte count on this path
-    if (result.done) return finish(decoder, buffer as string | Buffer[], length, received, done, received)
+    if (result.done) return onDone()
 
     // a stream of strings is already decoded, so decoding it
     // again with the declared encoding would corrupt the data
@@ -616,6 +640,8 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
         if (decoder) {
           // consumed immediately: the zero-copy view is safe
           buffer += decoder.write(chunk)
+        } else if (length !== null) {
+          append(chunk)
         } else {
           // copy: the producer may reuse the chunk's memory
           (buffer as Buffer[]).push(Buffer.from(chunk))
@@ -626,5 +652,21 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
 
       read()
     }
+  }
+
+  function onDone (): void {
+    if (length !== null && received !== length) {
+      return done(sizeMismatchError(length, received))
+    }
+
+    if (decoder === null && length !== null) {
+      if (body === null) return done(null, Buffer.alloc(0))
+
+      // zero-copy view of the accumulator
+      return done(null, Buffer.from(body.buffer, body.byteOffset, offset))
+    }
+
+    // received is an exact byte count on this path
+    finish(decoder, buffer as string | Buffer[], length, received, done, received)
   }
 }

--- a/test/index.bench.ts
+++ b/test/index.bench.ts
@@ -86,4 +86,18 @@ for (const scenario of scenarios) {
       await getRawBody(webStream(chunks), stringOptions)
     })
   })
+
+  // without a Content-Length the web path cannot preallocate the
+  // body and falls back to buffering chunks, like chunked encoding
+  describe(`${scenario.name} -> Buffer, unknown length`, () => {
+    const noLengthOptions = { limit: scenario.limit }
+
+    bench('node stream', async () => {
+      await getRawBody(nodeStream(chunks), noLengthOptions)
+    })
+
+    bench('web stream', async () => {
+      await getRawBody(webStream(chunks), noLengthOptions)
+    })
+  })
 }

--- a/test/webstream.spec.ts
+++ b/test/webstream.spec.ts
@@ -431,6 +431,36 @@ describe('using web streams', function () {
     assert.strictEqual(buf.toString(), 'aaaabbbbcccc')
   })
 
+  it('should copy reused chunk memory with a known length', async function () {
+    // same guarantee on the preallocated-body path taken
+    // when the length option is set
+    const scratch = new Uint8Array(4)
+    const parts = ['aaaa', 'bbbb', 'cccc']
+    let reads = 0
+
+    const stream = new ReadableStream<Uint8Array>({
+      pull (controller) {
+        if (reads === parts.length) return controller.close()
+        scratch.set(new TextEncoder().encode(parts[reads++]))
+        controller.enqueue(scratch)
+      }
+    })
+
+    const buf = await getRawBody(stream, { length: 12, limit: '1kb' })
+    assert.strictEqual(buf.toString(), 'aaaabbbbcccc')
+  })
+
+  it('should buffer more data than a capped allocation', async function () {
+    // without a limit the allocation starts capped at 1mb, so a
+    // later chunk must overflow it and force the body to grow
+    const chunk = Buffer.alloc(768 * 1024, 0x61)
+    const big = Buffer.concat([chunk, chunk])
+
+    const buf = await getRawBody(createWebStream([chunk, chunk]), { length: big.length })
+    assert.strictEqual(buf.length, big.length)
+    assert.ok(buf.equals(big))
+  })
+
   it('should release the lock when finished', async function () {
     const stream = createWebStream(['hello, world!'])
     await getRawBody(stream)


### PR DESCRIPTION
Something similar can be done for cases where the length isn't known, but I'll work on that in a follow-up PR. Also, based on the benchmarks I ran, `Uint8Array` is actually faster than `Buffer`.
