### PR TITLE
fix(webstreams): update buffer handling to support Uint8Array in finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ For web streams, any reader lock this module acquired is released both
 on success and on error, but the stream is never canceled, so on error
 you are responsible for disposing it, for example with `stream.cancel()`.
 
+Chunks read from a web stream are collected and assembled once at the
+end, without an intermediate copy. This relies on the producer following
+the streams contract and not reusing (or mutating) a chunk after it has
+been enqueued. Every standard source (a `fetch` `Response`/`Request`
+body, `Blob.stream()`, `Readable.toWeb`) satisfies this. If you build a
+custom `ReadableStream`, its underlying source must enqueue a fresh
+`Uint8Array` for each chunk rather than recycling one scratch buffer,
+otherwise the returned body may be corrupted.
+
 ## Errors
 
 This module creates errors with `status`/`statusCode`, the received and

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "4.75 KB",
+      "limit": "4.61 KB",
       "ignore": [
         "node:async_hooks",
         "node:stream"

--- a/src/index.ts
+++ b/src/index.ts
@@ -614,6 +614,8 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
     let chunk: Uint8Array
 
     if (typeof value === 'string') {
+      // a string-emitting stream (e.g. TextDecoderStream) is already
+      // text: encode it back to utf-8 bytes
       chunk = Buffer.from(value)
     } else if (value instanceof Uint8Array) {
       // kept as-is, not wrapped in a Buffer: concat and the decoder

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,12 +242,13 @@ function finish (decoder: Decoder | null, buffer: string | Buffer[], length: num
     if (decoder) {
       string = buffer + (decoder.end() || '')
     } else {
-      const chunks = buffer as Buffer[]
+      const chunks = buffer as Uint8Array[]
+      const first = chunks[0]
 
       // a body delivered in a single chunk, the common case for
       // small bodies, is handed over as-is instead of copied
       string = chunks.length === 1
-        ? chunks[0]
+        ? (Buffer.isBuffer(first) ? first : Buffer.from(first.buffer, first.byteOffset, first.byteLength))
         : Buffer.concat(chunks, total)
     }
   } catch (err) {
@@ -602,33 +603,38 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
   function onRead (result: ReadableStreamReadResult<Uint8Array | string>): void {
     if (result.done) return onDone()
 
+    const value = result.value
+
     // a stream of strings is already decoded, so decoding it
     // again with the declared encoding would corrupt the data
-    if (decoder && typeof result.value === 'string') {
+    if (decoder && typeof value === 'string') {
       return done(encodingSetError())
     }
 
-    let chunk: Buffer
+    let chunk: Uint8Array
 
-    try {
-      chunk = toBuffer(result.value)
-    } catch (err) {
-      return done(err as Error)
+    if (typeof value === 'string') {
+      chunk = Buffer.from(value)
+    } else if (value instanceof Uint8Array) {
+      // kept as-is, not wrapped in a Buffer: concat and the decoder
+      // both accept a Uint8Array
+      chunk = value
+    } else {
+      return done(new TypeError('stream chunks must be Uint8Array or string'))
     }
 
-    received += chunk.length
+    received += chunk.byteLength
 
     if (limit !== null && received > limit) {
       done(entityTooLargeError({ limit, received }))
     } else {
       try {
         if (decoder) {
-          // consumed immediately: the zero-copy view is safe
-          buffer += decoder.write(chunk)
+          buffer += decoder.write(toBuffer(chunk))
         } else {
           // held and assembled at the end, trusting the producer not
           // to reuse the chunk's memory, like the node path
-          (buffer as Buffer[]).push(chunk)
+          (buffer as Uint8Array[]).push(chunk)
         }
       } catch (err) {
         return done(err as Error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -641,5 +641,4 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
       read()
     }
   }
-
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -508,18 +508,11 @@ function readStream (stream: NodeJS.ReadableStream & { readableEncoding?: string
 }
 
 /**
- * Convert a web stream chunk to a Buffer.
+ * View a chunk as a Buffer, for a decoder that expects one.
  */
 
-function toBuffer (chunk: unknown): Buffer {
-  if (typeof chunk === 'string') return Buffer.from(chunk)
-  if (Buffer.isBuffer(chunk)) return chunk
-
-  if (chunk instanceof Uint8Array) {
-    return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
-  }
-
-  throw new TypeError('stream chunks must be Uint8Array or string')
+function toBuffer (chunk: Uint8Array): Buffer {
+  return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -527,8 +527,6 @@ function toBuffer (chunk: unknown): Buffer {
 
 function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: string | undefined | null, length: number | null, limit: number | null, createDecoder: CreateDecoder | undefined, callback: InternalCallback): void {
   let buffer: string | Buffer[] | null
-  let body: Uint8Array | null = null
-  let offset = 0
   let reader: ReadableStreamDefaultReader<Uint8Array | string> | null = null
 
   // check the length and limit options.
@@ -592,7 +590,6 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
 
   function done (err?: Error | null, string?: Buffer | string): void {
     buffer = null
-    body = null
 
     if (reader) {
       // release the stream, so users can handle the rest themselves
@@ -600,28 +597,6 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
     }
 
     callback(err, string)
-  }
-
-  /**
-   * Copy the chunk (the producer may reuse its memory) straight
-   * into the preallocated body, skipping the assembly copy.
-   */
-
-  function append (chunk: Buffer): void {
-    if (body === null) {
-      // only trust the declared length when the limit bounds it
-      const size = limit !== null ? length! : Math.min(length!, 1024 * 1024)
-
-      body = new Uint8Array(Math.max(size, received))
-    } else if (received > body.length) {
-      // excess over a capped allocation still has to be buffered
-      const grown = new Uint8Array(Math.max(body.length * 2, received))
-      grown.set(body.subarray(0, offset))
-      body = grown
-    }
-
-    body.set(chunk, offset)
-    offset = received
   }
 
   function onRead (result: ReadableStreamReadResult<Uint8Array | string>): void {
@@ -650,11 +625,10 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
         if (decoder) {
           // consumed immediately: the zero-copy view is safe
           buffer += decoder.write(chunk)
-        } else if (length !== null) {
-          append(chunk)
         } else {
-          // copy: the producer may reuse the chunk's memory
-          (buffer as Buffer[]).push(Buffer.from(chunk))
+          // held and assembled at the end, trusting the producer not
+          // to reuse the chunk's memory, like the node path
+          (buffer as Buffer[]).push(chunk)
         }
       } catch (err) {
         return done(err as Error)
@@ -665,17 +639,6 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
   }
 
   function onDone (): void {
-    if (length !== null && received !== length) {
-      return done(sizeMismatchError(length, received))
-    }
-
-    if (decoder === null && length !== null) {
-      if (body === null) return done(null, Buffer.alloc(0))
-
-      // zero-copy view of the accumulator
-      return done(null, Buffer.from(body.buffer, body.byteOffset, offset))
-    }
-
     // received is an exact byte count on this path
     finish(decoder, buffer as string | Buffer[], length, received, done, received)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -594,7 +594,10 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
   }
 
   function onRead (result: ReadableStreamReadResult<Uint8Array | string>): void {
-    if (result.done) return onDone()
+    if (result.done) {
+      // received is an exact byte count on this path
+      return finish(decoder, buffer as string | Buffer[], length, received, done, received)
+    }
 
     const value = result.value
 
@@ -639,8 +642,4 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
     }
   }
 
-  function onDone (): void {
-    // received is an exact byte count on this path
-    finish(decoder, buffer as string | Buffer[], length, received, done, received)
-  }
 }

--- a/test/webstream.spec.ts
+++ b/test/webstream.spec.ts
@@ -411,48 +411,7 @@ describe('using web streams', function () {
     assert.strictEqual(stream.locked, false)
   })
 
-  it('should copy chunks whose memory the producer reuses', async function () {
-    // a producer may legally recycle one scratch buffer
-    // across enqueues; retained views would all end up
-    // pointing at the last chunk's bytes
-    const scratch = new Uint8Array(4)
-    const parts = ['aaaa', 'bbbb', 'cccc']
-    let reads = 0
-
-    const stream = new ReadableStream<Uint8Array>({
-      pull (controller) {
-        if (reads === parts.length) return controller.close()
-        scratch.set(new TextEncoder().encode(parts[reads++]))
-        controller.enqueue(scratch)
-      }
-    })
-
-    const buf = await getRawBody(stream)
-    assert.strictEqual(buf.toString(), 'aaaabbbbcccc')
-  })
-
-  it('should copy reused chunk memory with a known length', async function () {
-    // same guarantee on the preallocated-body path taken
-    // when the length option is set
-    const scratch = new Uint8Array(4)
-    const parts = ['aaaa', 'bbbb', 'cccc']
-    let reads = 0
-
-    const stream = new ReadableStream<Uint8Array>({
-      pull (controller) {
-        if (reads === parts.length) return controller.close()
-        scratch.set(new TextEncoder().encode(parts[reads++]))
-        controller.enqueue(scratch)
-      }
-    })
-
-    const buf = await getRawBody(stream, { length: 12, limit: '1kb' })
-    assert.strictEqual(buf.toString(), 'aaaabbbbcccc')
-  })
-
-  it('should buffer more data than a capped allocation', async function () {
-    // without a limit the allocation starts capped at 1mb, so a
-    // later chunk must overflow it and force the body to grow
+  it('should assemble a large multi-chunk body', async function () {
     const chunk = Buffer.alloc(768 * 1024, 0x61)
     const big = Buffer.concat([chunk, chunk])
 

--- a/test/webstream.spec.ts
+++ b/test/webstream.spec.ts
@@ -56,13 +56,17 @@ describe('using web streams', function () {
     // re-encodes them to utf-8. multi-byte characters split across the
     // underlying byte chunks must survive the round trip.
     const bytes = Buffer.from('café ☕ 好', 'utf-8')
-    const byteChunks: Uint8Array[] = []
 
-    for (let i = 0; i < bytes.length; i += 2) {
-      byteChunks.push(bytes.subarray(i, i + 2))
-    }
+    const byteStream = new ReadableStream<NodeJS.BufferSource>({
+      start (controller) {
+        for (let i = 0; i < bytes.length; i += 2) {
+          controller.enqueue(bytes.subarray(i, i + 2))
+        }
+        controller.close()
+      }
+    })
 
-    const stream = createWebStream(byteChunks).pipeThrough(new TextDecoderStream())
+    const stream = byteStream.pipeThrough(new TextDecoderStream())
     const buf = await getRawBody(stream)
 
     assert.ok(Buffer.isBuffer(buf))

--- a/test/webstream.spec.ts
+++ b/test/webstream.spec.ts
@@ -51,6 +51,24 @@ describe('using web streams', function () {
     assert.strictEqual(buf.toString(), 'hello, world!')
   })
 
+  it('should read a TextDecoderStream as a utf-8 Buffer', async function () {
+    // TextDecoderStream emits already-decoded string chunks; getRawBody
+    // re-encodes them to utf-8. multi-byte characters split across the
+    // underlying byte chunks must survive the round trip.
+    const bytes = Buffer.from('café ☕ 好', 'utf-8')
+    const byteChunks: Uint8Array[] = []
+
+    for (let i = 0; i < bytes.length; i += 2) {
+      byteChunks.push(bytes.subarray(i, i + 2))
+    }
+
+    const stream = createWebStream(byteChunks).pipeThrough(new TextDecoderStream())
+    const buf = await getRawBody(stream)
+
+    assert.ok(Buffer.isBuffer(buf))
+    assert.strictEqual(buf.toString('utf-8'), 'café ☕ 好')
+  })
+
   it('should error on string chunks when encoding is set', async function () {
     // an already-decoded stream, e.g. piped through TextDecoderStream;
     // re-decoding it with the declared encoding would corrupt the data


### PR DESCRIPTION
Okay, after digging into this a bit more, I found a potential DoS issue caused by preserving behavior that was actually based on incorrect API usage. We used to protect against that, but now we fully rely on `ReadableStream` implementations following the spec and not mutating their own buffers. Also, since Web Streams naturally emit `Uint8Array` chunks, we can optimize this by avoiding copying the data into a new `Buffer`.
