### PR TITLE
fix: improve length handling

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -46,6 +46,10 @@
 
 ### 🐞 Bug fixes
 
+- Fix a `length` that does not parse to a number failing every request - by [@bjohansebas](https://github.com/bjohansebas) in [#172](https://github.com/stream-utils/raw-body/pull/172)
+
+    Values like `''` passed the numeric pre-check but parsed to `NaN`, so the size check could never match and every request errored with a 400 `request.size.invalid`. They are now treated as no expected length, like any other unparseable value.
+
 - Fix node streams destroyed without an error never settling - by [@bjohansebas](https://github.com/bjohansebas) in [#158](https://github.com/stream-utils/raw-body/pull/158)
 
     They now error through the callback / reject the promise with the same 400 `request.aborted` error as the web path, instead of never invoking the callback or settling the promise.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,6 +40,10 @@
 
     `npm run bench` compares the node and web stream paths with realistic request bodies.
 
+- Fail as soon as a stream exceeds its declared `length` - by [@bjohansebas](https://github.com/bjohansebas) in [#172](https://github.com/stream-utils/raw-body/pull/172)
+
+    A body that sends more bytes than its declared `length` now errors with a 400 `request.size.invalid` as soon as the excess arrives, rather than buffering the rest first. This bounds memory to `length` even when no `limit` is set. When both are set, a `length` overrun is reported before the `limit`'s 413.
+
 ### 🐞 Bug fixes
 
 - Fix node streams destroyed without an error never settling - by [@bjohansebas](https://github.com/bjohansebas) in [#158](https://github.com/stream-utils/raw-body/pull/158)

--- a/src/index.ts
+++ b/src/index.ts
@@ -337,10 +337,11 @@ function getRawBody (stream: RawBodyStream, options?: Readonly<Options> | Encodi
     throw new TypeError('option limit must be a number of bytes or a byte size string')
   }
 
-  // convert the expected length to an integer
-  const length = opts.length != null && !Number.isNaN(Number(opts.length))
+  // convert the expected length to an integer.
+  const parsedLength = opts.length != null && !Number.isNaN(Number(opts.length))
     ? parseInt(String(opts.length), 10)
-    : null
+    : NaN
+  const length = Number.isNaN(parsedLength) ? null : parsedLength
 
   // select the reader for the stream type.
   // node streams take precedence, so objects exposing both

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,6 +476,10 @@ function readStream (stream: NodeJS.ReadableStream & { readableEncoding?: string
 
     if (limit !== null && received > limit) {
       done(entityTooLargeError({ limit, received }))
+    } else if (length !== null && received > length) {
+      // past the declared length: a size mismatch, reported now like
+      // finish() does at stream end, instead of buffering the rest
+      done(sizeMismatchError(length, received))
     } else if (decoder) {
       try {
         buffer += decoder.write(chunk)
@@ -625,6 +629,10 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
 
     if (limit !== null && received > limit) {
       done(entityTooLargeError({ limit, received }))
+    } else if (length !== null && received > length) {
+      // past the declared length: a size mismatch, reported now like
+      // finish() does at stream end, instead of buffering the rest
+      done(sizeMismatchError(length, received))
     } else {
       try {
         if (decoder) {

--- a/test/flowing.spec.ts
+++ b/test/flowing.spec.ts
@@ -42,9 +42,11 @@ describe('stream flowing', function () {
         length: defaultLimit
       }, function (err, body) {
         assert.ok(err)
-        assert.strictEqual(err.type, 'entity.too.large')
-        assert.strictEqual(err.message, 'request entity too large')
-        assert.strictEqual(err.statusCode, 413)
+        // the body passes its declared length before reaching the
+        // limit, so it halts on a size mismatch rather than a 413
+        assert.strictEqual(err.type, 'request.size.invalid')
+        assert.strictEqual(err.message, 'request size did not match content length')
+        assert.strictEqual(err.statusCode, 400)
         assert.strictEqual(body, undefined)
         assert.ok(stream.isPaused())
         done()

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -77,6 +77,28 @@ describe('Raw Body', function () {
     })
   }))
 
+  it('should ignore a length that does not parse to a number', withDone(function (done) {
+    getRawBody(createStream(), {
+      // Number('') is 0, but parseInt('') is NaN: it must mean
+      // no expected length, not a guaranteed size mismatch
+      length: ''
+    }, function (err, buf) {
+      assert.ifError(err)
+      checkBuffer(buf)
+      done()
+    })
+  }))
+
+  it('should ignore a whitespace-only length', withDone(function (done) {
+    getRawBody(createStream(), {
+      length: ' '
+    }, function (err, buf) {
+      assert.ifError(err)
+      checkBuffer(buf)
+      done()
+    })
+  }))
+
   it('should work with limit', withDone(function (done) {
     getRawBody(createStream(), {
       limit: length + 1


### PR DESCRIPTION
Basically, we added a check while reading the data instead of waiting until the `end` event. This gives us an early check for something that would otherwise only be detected at the `end` event. It also fixes a small bug in the limit parser when handling invalid values.
