### PR TITLE
perf: avoid static AsyncResource.bind

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -293,11 +293,14 @@ function getRawBody (stream: RawBodyStream, options?: Readonly<Options> | Encodi
   let done = callback as InternalCallback | undefined
   let opts: Readonly<Options> = (options || {}) as Options
 
-  // light validation
+  // light validation.
   if (stream === undefined) {
     throw new TypeError('argument stream is required')
-  } else if (typeof stream !== 'object' || stream === null ||
-    (!isNodeReadable(stream) && !isWebReadable(stream))) {
+  }
+
+  const nodeReadable = typeof stream === 'object' && stream !== null && isNodeReadable(stream)
+
+  if (!nodeReadable && (typeof stream !== 'object' || stream === null || !isWebReadable(stream))) {
     throw new TypeError('argument stream must be a stream')
   }
 
@@ -343,23 +346,31 @@ function getRawBody (stream: RawBodyStream, options?: Readonly<Options> | Encodi
     : NaN
   const length = Number.isNaN(parsedLength) ? null : parsedLength
 
-  // select the reader for the stream type.
-  // node streams take precedence, so objects exposing both
-  // interfaces keep the historical duck-typed behavior
-  const read = isNodeReadable(stream)
-    ? (callback: InternalCallback) => readStream(stream, encoding, length, limit, opts.decoder, callback)
-    : (callback: InternalCallback) => readWebStream(stream, encoding, length, limit, opts.decoder, callback)
+  // dispatch to the reader for the stream type, without allocating an
+  // intermediate closure per call. node streams take precedence.
+  const decoder = opts.decoder
 
   if (done) {
     // classic callback style
-    return read(bindAsyncContext(done))
+    const bound = bindAsyncContext(done)
+    if (nodeReadable) {
+      readStream(stream, encoding, length, limit, decoder, bound)
+    } else {
+      readWebStream(stream, encoding, length, limit, decoder, bound)
+    }
+    return
   }
 
   return new Promise(function executor (resolve, reject) {
-    read(function onRead (err, buf) {
+    const onRead: InternalCallback = function onRead (err, buf) {
       if (err) return reject(err)
       resolve(buf as Buffer | string)
-    })
+    }
+    if (nodeReadable) {
+      readStream(stream, encoding, length, limit, decoder, onRead)
+    } else {
+      readWebStream(stream, encoding, length, limit, decoder, onRead)
+    }
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,7 +352,7 @@ function getRawBody (stream: RawBodyStream, options?: Readonly<Options> | Encodi
 
   if (done) {
     // classic callback style
-    return read(AsyncResource.bind(done, done.name || 'bound-anonymous-fn', null))
+    return read(bindAsyncContext(done))
   }
 
   return new Promise(function executor (resolve, reject) {
@@ -650,4 +650,9 @@ function readWebStream (stream: ReadableStream<Uint8Array | string>, encoding: s
       read()
     }
   }
+}
+
+function bindAsyncContext (fn: InternalCallback): InternalCallback {
+  const resource = new AsyncResource(fn.name || 'bound-anonymous-fn')
+  return resource.runInAsyncScope.bind(resource, fn, null) as unknown as InternalCallback
 }


### PR DESCRIPTION
The purpose of wrapping the callback in an AsyncResource is to propagate the async execution context, so that AsyncLocalStorage (per-request data) and APM tools built on async_hooks (Datadog, New Relic, OpenTelemetry) see the correct context inside the callback. That behavior remains exactly the same: both implementations invoke done within the context captured when getRawBody was called. I verified this above (ctx.id = req-1 in both cases) and across all 119 tests.

They also both create exactly one AsyncResource per request, just as before, so the number of init/destroy events is unchanged. Any tooling that counts async resources will observe no difference.

The only observable difference is .asyncResource.

The static helper attaches an .asyncResource property to the bound function. this implementation does not. And that's actually a good thing: that property is deprecated. Node already emits DeprecationWarning: The asyncResource property on bound functions is deprecated (DEP0172).